### PR TITLE
Make drm_timestamp_precision and drm_vblank_offdelay visible outside …

### DIFF
--- a/drivers/gpu/drm/drm_vblank.c
+++ b/drivers/gpu/drm/drm_vblank.c
@@ -80,9 +80,9 @@ static bool
 drm_get_last_vbltimestamp(struct drm_device *dev, unsigned int pipe,
 			  ktime_t *tvblank, bool in_vblank_irq);
 
-static unsigned int drm_timestamp_precision = 20;  /* Default to 20 usecs. */
+unsigned int drm_timestamp_precision = 20;  /* Default to 20 usecs. */
 
-static int drm_vblank_offdelay = 5000;    /* Default to 5000 msecs. */
+int drm_vblank_offdelay = 5000;    /* Default to 5000 msecs. */
 
 module_param_named(vblankoffdelay, drm_vblank_offdelay, int, 0600);
 module_param_named(timestamp_precision_usec, drm_timestamp_precision, int, 0600);


### PR DESCRIPTION
…the compilation unit

Signed-off-by: Jorge Maidana <jorgem.seq@gmail.com>