### PR TITLE
Get Navi10 card working on FreeBSD

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/psp_v11_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/psp_v11_0.c
@@ -299,7 +299,7 @@ static int psp_v11_0_bootloader_load_sos(struct psp_context *psp)
 	       psp_gfxdrv_command_reg);
 
 	/* there might be handshake issue with hardware which needs delay */
-	mdelay(20);
+	mdelay(200);
 	ret = psp_wait_for(psp, SOC15_REG_OFFSET(MP0, 0, mmMP0_SMN_C2PMSG_81),
 			   RREG32_SOC15(MP0, 0, mmMP0_SMN_C2PMSG_81),
 			   0, true);

--- a/drivers/gpu/drm/amd/amdgpu/psp_v11_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/psp_v11_0.c
@@ -299,7 +299,11 @@ static int psp_v11_0_bootloader_load_sos(struct psp_context *psp)
 	       psp_gfxdrv_command_reg);
 
 	/* there might be handshake issue with hardware which needs delay */
-	mdelay(200);
+#ifdef __linux__
+	mdelay(20);
+#elif defined(__FreeBSD__)
+	mdelay(30);
+#endif	
 	ret = psp_wait_for(psp, SOC15_REG_OFFSET(MP0, 0, mmMP0_SMN_C2PMSG_81),
 			   RREG32_SOC15(MP0, 0, mmMP0_SMN_C2PMSG_81),
 			   0, true);

--- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
@@ -2035,6 +2035,7 @@ bool dcn20_validate_bandwidth(struct dc *dc, struct dc_state *context,
 	if (!pipes)
 		return false;
 
+	kernel_fpu_begin();
 	for (i = 0; i < dc->res_pool->pipe_count; i++) {
 		struct pipe_ctx *pipe = &context->res_ctx.pipe_ctx[i];
 		struct pipe_ctx *hsplit_pipe = pipe->bottom_pipe;
@@ -2397,6 +2398,7 @@ validate_fail:
 	out = false;
 
 validate_out:
+	kernel_fpu_end();
 	kfree(pipes);
 
 	BW_VAL_TRACE_FINISH();
@@ -3017,6 +3019,7 @@ static bool construct(
 
 			ranges.num_reader_wm_sets = 1;
 		} else if (dcn2_0_soc.num_states > 1) {
+			kernel_fpu_begin();
 			for (i = 0; i < 4 && i < dcn2_0_soc.num_states; i++) {
 				ranges.reader_wm_sets[i].wm_inst = i;
 				ranges.reader_wm_sets[i].min_drain_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MIN;
@@ -3026,7 +3029,7 @@ static bool construct(
 
 				ranges.num_reader_wm_sets = i + 1;
 			}
-
+			kernel_fpu_end();
 			ranges.reader_wm_sets[0].min_fill_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MIN;
 			ranges.reader_wm_sets[ranges.num_reader_wm_sets - 1].max_fill_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MAX;
 		}

--- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
@@ -2035,7 +2035,9 @@ bool dcn20_validate_bandwidth(struct dc *dc, struct dc_state *context,
 	if (!pipes)
 		return false;
 
+#ifdef __FreeBSD__	
 	kernel_fpu_begin();
+#endif
 	for (i = 0; i < dc->res_pool->pipe_count; i++) {
 		struct pipe_ctx *pipe = &context->res_ctx.pipe_ctx[i];
 		struct pipe_ctx *hsplit_pipe = pipe->bottom_pipe;
@@ -2398,7 +2400,9 @@ validate_fail:
 	out = false;
 
 validate_out:
+#ifdef __FreeBSD__
 	kernel_fpu_end();
+#endif	
 	kfree(pipes);
 
 	BW_VAL_TRACE_FINISH();
@@ -3019,7 +3023,9 @@ static bool construct(
 
 			ranges.num_reader_wm_sets = 1;
 		} else if (dcn2_0_soc.num_states > 1) {
+#ifdef __FreeBSD__
 			kernel_fpu_begin();
+#endif
 			for (i = 0; i < 4 && i < dcn2_0_soc.num_states; i++) {
 				ranges.reader_wm_sets[i].wm_inst = i;
 				ranges.reader_wm_sets[i].min_drain_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MIN;
@@ -3029,7 +3035,9 @@ static bool construct(
 
 				ranges.num_reader_wm_sets = i + 1;
 			}
+#ifdef __FreeBSD__
 			kernel_fpu_end();
+#endif
 			ranges.reader_wm_sets[0].min_fill_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MIN;
 			ranges.reader_wm_sets[ranges.num_reader_wm_sets - 1].max_fill_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MAX;
 		}


### PR DESCRIPTION
These are the changes that are needed to get the drm driver working with a Navi10 card on FreeBSD. They consist of

1. Increase mdelay in SOS loading (from 20 to 200).
2. Wrap some floating point operations with `kernel_fpu_begin/end` pairs.

I would say the first change probably needs consideration. I did not spend time to find out how much the mdelay should increase. The only error the `psp_wait_for()` function can return is that it timed out. So, I just started with a large number and didn't look at reducing it. It might be better to get the the pull request in and the card working before looking at reducing this time afterwards.

Anyway, with these changes and the mesa_devel package, X11 works. Haven't tried Wayland.