### PR TITLE
linuxkpi cleanup

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu.h
@@ -89,7 +89,6 @@
 #include "amdgpu_umc.h"
 #include "amdgpu_mmhub.h"
 
-#define firmware linux_firmware
 #define MAX_GPU_INSTANCE		16
 
 struct amdgpu_gpu_instance

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ucode.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ucode.h
@@ -337,11 +337,7 @@ struct amdgpu_firmware_info {
 	/* ucode ID */
 	enum AMDGPU_UCODE_ID ucode_id;
 	/* request_firmware */
-#ifdef __linux__
 	const struct firmware *fw;
-#elif defined(__FreeBSD__)
-	const struct linux_firmware *fw;
-#endif
 	/* starting mc address */
 	uint64_t mc_addr;
 	/* kernel linear address */
@@ -381,7 +377,7 @@ void amdgpu_ucode_print_gpu_info_hdr(const struct common_firmware_header *hdr);
 #ifdef __linux__
 int amdgpu_ucode_validate(const struct firmware *fw);
 #elif defined(__FreeBSD__)
-int amdgpu_ucode_validate(const struct linux_firmware *fw);
+int amdgpu_ucode_validate(const struct firmware *fw);
 #endif
 bool amdgpu_ucode_hdr_version(union amdgpu_firmware_header *hdr,
 				uint16_t hdr_major, uint16_t hdr_minor);

--- a/drivers/gpu/drm/radeon/radeon.h
+++ b/drivers/gpu/drm/radeon/radeon.h
@@ -80,8 +80,6 @@
 #include "radeon_mode.h"
 #include "radeon_reg.h"
 
-#define firmware linux_firmware
-
 /*
  * Modules parameters.
  */

--- a/linuxkpi/gplv2/include/linux/dma-fence.h
+++ b/linuxkpi/gplv2/include/linux/dma-fence.h
@@ -576,7 +576,7 @@ u64 dma_fence_context_alloc(unsigned num);
 #define DMA_FENCE_TRACE(f, fmt, args...) \
 	do {								\
 		struct dma_fence *__ff = (f);				\
-		if (config_enabled(CONFIG_DMA_FENCE_TRACE))			\
+		if (IS_BUILTIN(CONFIG_DMA_FENCE_TRACE))			\
 			pr_info("f %u#%u: " fmt,			\
 				__ff->context, __ff->seqno, ##args);	\
 	} while (0)


### PR DESCRIPTION
Remove multiple duplicate linux_fimrware related changes inside drivers which linux/firmware.h already handles.
Also use a more portable (official) macro name within the implementation to allow for portability.