### PR TITLE
Remove #ifdef __linux__ from dma-resv.c

### DIFF
--- a/drivers/dma-buf/dma-resv.c
+++ b/drivers/dma-buf/dma-resv.c
@@ -70,13 +70,8 @@ static struct dma_resv_list *dma_resv_list_alloc(unsigned int shared_max)
 	if (!list)
 		return NULL;
 
-#ifdef __linux__
 	list->shared_max = (ksize(list) - offsetof(typeof(*list), shared)) /
 		sizeof(*list->shared);
-#elif defined(__FreeBSD__)
-	list->shared_max = (offsetof(typeof(*list), shared[shared_max]) - offsetof(typeof(*list), shared)) /
-		sizeof(*list->shared);
-#endif
 
 	return list;
 }


### PR DESCRIPTION
LinuxKPI in base have ksize() implemented since r364964.