### PR TITLE
linuxkpi: deal with (upcoming) conflicts from head

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -528,6 +528,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H:H}/include

--- a/amd/amdkfd/Makefile
+++ b/amd/amdkfd/Makefile
@@ -40,6 +40,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H:H}/include

--- a/drivers/gpu/drm/drm_os_freebsd.h
+++ b/drivers/gpu/drm/drm_os_freebsd.h
@@ -104,6 +104,7 @@ do {								\
 	({ __typeof__(*(ptr)) __tmp;                                    \
 	  memcpy(&__tmp, (ptr), sizeof(*(ptr))); __tmp; })
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 #if _BYTE_ORDER == _LITTLE_ENDIAN
 /* Taken from linux/include/linux/unaligned/le_struct.h. */
 struct __una_u32 { u32 x; } __packed;
@@ -137,6 +138,7 @@ get_unaligned_le32(const void *p)
 
 	return (__get_unaligned_le32((const u8 *)p));
 }
+#endif
 #endif
 
 #define	page_to_phys(x) VM_PAGE_TO_PHYS(x)

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -129,6 +129,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include # fallback to dummy
 CFLAGS+= -I${SRCDIR}
 CFLAGS+= -I${.CURDIR:H}/include

--- a/dummygfx/Makefile
+++ b/dummygfx/Makefile
@@ -13,6 +13,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -201,6 +201,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include

--- a/linuxkpi/Makefile
+++ b/linuxkpi/Makefile
@@ -48,6 +48,9 @@ CFLAGS+= -I${.CURDIR:H}/include
 CFLAGS+= -I${.CURDIR}/dummy/include
 CFLAGS+= -I${.CURDIR}/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"' -DLINUXKPI_VERSION=50000
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 CFLAGS.gcc+= -Wno-cast-qual

--- a/linuxkpi/dummy/include/linux/cpu.h
+++ b/linuxkpi/dummy/include/linux/cpu.h
@@ -1,0 +1,4 @@
+
+#if defined(LINUXKPI_COOKIE) && (LINUXKPI_COOKIE >= 1600256818)
+#include_next <linux/cpu.h>
+#endif

--- a/linuxkpi/gplv2/include/linux/device.h
+++ b/linuxkpi/gplv2/include/linux/device.h
@@ -25,6 +25,7 @@ struct devres_group {
 	int				color;
 };
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 static inline void *
 devm_kmalloc(struct device *dev, size_t size, gfp_t gfp)
 {
@@ -47,6 +48,7 @@ devm_kcalloc(struct device *dev, size_t n, size_t size, gfp_t gfp)
 {
 	return devm_kmalloc(dev, n * size, gfp | __GFP_ZERO);
 }
+#endif
 
 /*
  * drivers/base/devres.c - device resource management

--- a/linuxkpi/gplv2/include/linux/firmware.h
+++ b/linuxkpi/gplv2/include/linux/firmware.h
@@ -1,6 +1,7 @@
 #ifndef _LINUX_FIRMWARE_H
 #define _LINUX_FIRMWARE_H
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 #include <linux/types.h>
 #include <linux/compiler.h>
 #include <linux/gfp.h>
@@ -49,4 +50,12 @@ int request_firmware_nowait(
 
 void release_firmware(const struct linux_firmware *fw);
 #define firmware linux_firmware
+#else
+
+#include_next <linux/firmware.h>
+
+#define	request_firmware_direct(f,n,d) request_firmware(f,n,d)
+#endif
+
+
 #endif

--- a/linuxkpi/gplv2/include/linux/kconfig.h
+++ b/linuxkpi/gplv2/include/linux/kconfig.h
@@ -1,5 +1,7 @@
 #ifndef __LINUX_KCONFIG_H
 #define __LINUX_KCONFIG_H
+
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 #if 0
 #include <generated/autoconf.h>
 #endif
@@ -51,5 +53,6 @@
  */
 #define IS_ENABLED(option) \
 	(IS_BUILTIN(option) || IS_MODULE(option))
+#endif
 
 #endif /* __LINUX_KCONFIG_H */

--- a/linuxkpi/gplv2/include/linux/kobject.h
+++ b/linuxkpi/gplv2/include/linux/kobject.h
@@ -3,6 +3,7 @@
 
 #include_next <linux/kobject.h>
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 enum kobject_action {
 	KOBJ_ADD,
 	KOBJ_REMOVE,
@@ -22,5 +23,6 @@ kobject_uevent_env(struct kobject *kobj __unused,
 
 	return (0);
 }
+#endif
 
 #endif

--- a/linuxkpi/gplv2/include/linux/pci.h
+++ b/linuxkpi/gplv2/include/linux/pci.h
@@ -98,12 +98,16 @@ pci_bus_write_config_byte(struct pci_bus *bus, unsigned int devfn, int where,
 	return (pci_bus_write_config(bus, devfn, where, val, 1));
 }
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 static inline int
 pci_domain_nr(struct pci_bus *bus)
 {
 
 	return (0);
 }
+
+void pci_dev_put(struct pci_dev *pdev);
+#endif
 
 extern struct pci_dev *pci_get_bus_and_slot(unsigned int bus, unsigned int devfn);
 
@@ -114,7 +118,6 @@ pci_get_domain_bus_and_slot(int domain, unsigned int bus, unsigned int devfn)
 	return (pci_get_bus_and_slot(bus, devfn));
 }
 
-void pci_dev_put(struct pci_dev *pdev);
 
 static inline bool
 pci_is_root_bus(struct pci_bus *pbus)

--- a/linuxkpi/gplv2/include/linux/pm.h
+++ b/linuxkpi/gplv2/include/linux/pm.h
@@ -28,6 +28,9 @@
 #include <linux/wait.h>
 #include <linux/timer.h>
 #include <linux/completion.h>
+#if defined(LINUXKPI_COOKIE) && (LINUXKPI_COOKIE >= 1600256818)
+#include_next <linux/pm.h>
+#endif
 
 #define	DPM_FLAG_NEVER_SKIP	BIT(0)
 #define	DPM_FLAG_SMART_PREPARE	BIT(1)
@@ -37,6 +40,7 @@ struct device;
 
 extern const char power_group_name[];		/* = "power" */
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 /*
  * Use this if you want to use the same suspend and resume callbacks for suspend
  * to RAM and hibernation.
@@ -58,6 +62,7 @@ extern const char power_group_name[];		/* = "power" */
 const struct dev_pm_ops name = { \
 	SET_SYSTEM_SLEEP_PM_OPS(suspend_fn, resume_fn) \
 }
+#endif
 
 struct dev_pm_domain {
         struct dev_pm_ops       ops;

--- a/linuxkpi/gplv2/include/linux/scatterlist.h
+++ b/linuxkpi/gplv2/include/linux/scatterlist.h
@@ -31,6 +31,7 @@
 
 #include_next <linux/scatterlist.h>
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 static inline size_t
 sg_pcopy_from_buffer(struct scatterlist *sgl, unsigned int nents,
     const void *buf, size_t buflen, off_t offset)
@@ -68,6 +69,7 @@ sg_pcopy_from_buffer(struct scatterlist *sgl, unsigned int nents,
 	}
 	return (total);
 }
+#endif
 
 static inline size_t
 sg_copy_from_buffer(struct scatterlist *sgl, unsigned int nents,

--- a/linuxkpi/gplv2/include/linux/seqlock.h
+++ b/linuxkpi/gplv2/include/linux/seqlock.h
@@ -54,7 +54,9 @@ typedef struct seqcount {
 } seqcount_t;
 
 
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 #define lockdep_init_map(a, b, c, d)
+#endif
 
 static inline void __seqcount_init(seqcount_t *s, const char *name,
 					  struct lock_class_key *key)

--- a/linuxkpi/gplv2/src/linux_firmware.c
+++ b/linuxkpi/gplv2/src/linux_firmware.c
@@ -1,3 +1,4 @@
+#if !defined(LINUXKPI_COOKIE) || (LINUXKPI_COOKIE < 1600256818)
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/kernel.h>
@@ -121,3 +122,4 @@ release_firmware(const struct linux_firmware *lkfw)
 	free(__DECONST(void *, lkfw), M_LKPI_FW);
 	firmware_put(fw, 0);
 }
+#endif

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -124,6 +124,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -26,6 +26,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include

--- a/vboxvideo/Makefile
+++ b/vboxvideo/Makefile
@@ -26,6 +26,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include

--- a/vmwgfx/Makefile
+++ b/vmwgfx/Makefile
@@ -50,6 +50,9 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
+.if exists(${SYSDIR}/compat/linuxkpi/common/linuxkpi.h)
+CFLAGS+= -include ${SYSDIR}/compat/linuxkpi/common/linuxkpi.h
+.endif
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include


### PR DESCRIPTION
The linuxkpi changes mentioned in https://reviews.freebsd.org/D26598
conflict with the current implementation of kmod-drm.
In order to at least allow for the source code updates to be done
more smoothly implement a scheme which will detect once these
changes are in base and automatically disable the local implementation.

In addition to this the base system linuxkpi implementation differs
in some part from here.  Add the missing bits taken from the base
system implementation in linux_device.c and enabled them on switch
as well.

Note: the linuxkpi.h file is not up for review yet, as some general
Makefile infrastructure might also be done along.
This is put up for (p)review so that the in- and out-of-tree changes
can be deiscussed more easily.

Note2: this also depends on https://github.com/FreeBSDDesktop/kms-firmware/pull/13
which allows all firmware modules to be auto-loaded without needing any
special "pre-load" magic in the compat code.  The DRM implementation
seems to be the only one which requires this.

Sponsored by:  The FreeBSD Foundation