### PR TITLE
Fix ACPI vs amdgpu 'BOOLEAN' typedef conflict

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/dm_pp_smu.h
+++ b/drivers/gpu/drm/amd/display/dc/dm_pp_smu.h
@@ -30,9 +30,7 @@
  * interface to PPLIB/SMU to setup clocks and pstate requirements on SoC
  */
 
-#if !defined(__i386__) && !defined(__amd64__) && !defined(__aarch64__)
 typedef bool BOOLEAN;
-#endif
 
 enum pp_smu_ver {
 	/*
@@ -246,13 +244,8 @@ struct pp_smu_funcs_nv {
 	 * request to go un-acked.  Only when the call completes should such a state be applied to
 	 * DC hardware
 	 */
-#ifdef __linux__
 	enum pp_smu_status (*set_pstate_handshake_support)(struct pp_smu *pp,
 			BOOLEAN pstate_handshake_supported);
-#elif defined(__FreeBSD__)
-	enum pp_smu_status (*set_pstate_handshake_support)(struct pp_smu *pp,
-			bool pstate_handshake_supported);
-#endif
 };
 #endif
 

--- a/linuxkpi/gplv2/include/linux/acpi.h
+++ b/linuxkpi/gplv2/include/linux/acpi.h
@@ -29,10 +29,14 @@
 #include <linux/list.h>
 #include <linux/mod_devicetable.h>
 
+/* FreeBSD ACPI code has a typedef for BOOLEAN which conflicts with amdgpu,
+ * so let's change it to defining something else */
+#define BOOLEAN ACPI_BOOLEAN
 #include <contrib/dev/acpica/include/acpi.h>
 #include <acpi/acpi.h>
 #include <acpi/acpi_bus.h>
 #include <acpi/acpi_drivers.h>
+#undef BOOLEAN
 
 static inline acpi_handle acpi_device_handle(struct acpi_device *adev)
 {


### PR DESCRIPTION
Currently there are preprocessor workarounds in amdgpu but they were erroring for me:

```
drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_pp_smu.c:945:48: error: incompatible pointer types assigning to 'enum pp_smu_status (*)(struct pp_smu *, bool)' (aka 'enum pp_smu_status (*)(struct pp_smu
 *, _Bool)') from 'enum pp_smu_status (struct pp_smu *, BOOLEAN)' (aka 'enum pp_smu_status (struct pp_smu *, unsigned char)') [-Werror,-Wincompatible-pointer-types]
                funcs->nv_funcs.set_pstate_handshake_support = pp_nv_set_pstate_handshake_support;
```

Maybe this way is better??
(or, `#define BOOLEAN AMDGPU_BOOLEAN` in amdgpu?)

cc @wulf7 for #30