### PR TITLE
drm_prime_handle_to_fd_ioctl: translate O_ flags for Linuxulator

### DIFF
--- a/drivers/gpu/drm/drm_prime.c
+++ b/drivers/gpu/drm/drm_prime.c
@@ -26,6 +26,12 @@
  *
  */
 
+#if defined(__FreeBSD__)
+#include <sys/sysent.h>
+#define	LINUX_O_RDWR		00000002
+#define	LINUX_O_CLOEXEC		02000000
+#endif
+
 #include <linux/export.h>
 #include <linux/dma-buf.h>
 #include <linux/rbtree.h>
@@ -519,6 +525,11 @@ int drm_prime_handle_to_fd_ioctl(struct drm_device *dev, void *data,
 		return -ENOSYS;
 
 	/* check flags are valid */
+#if defined(__FreeBSD__) && defined(SV_ABI_LINUX)
+	if (SV_CURPROC_ABI() == SV_ABI_LINUX)
+		args->flags = ((args->flags & LINUX_O_CLOEXEC) ? DRM_CLOEXEC : 0)
+			| ((args->flags & LINUX_O_RDWR) ? DRM_RDWR : 0);
+#endif
 	if (args->flags & ~(DRM_CLOEXEC | DRM_RDWR))
 		return -EINVAL;
 


### PR DESCRIPTION
Fixes https://github.com/FreeBSDDesktop/kms-drm/issues/248 (damn why do we still have two repositories >_<)

note: I first wanted to do this in `linux_ioctl.c` in the linuxulator itself, but there we get the ioctl data *before* copying it from userspace, so that would mean copyin-fix-copyout which is awful.

testing: `/compat/linux/bin/strace /compat/linux/bin/glxgears` without any dri3 disabling variables (might also need to rebuild and reload `linsysfs` with https://reviews.freebsd.org/D26836 applied especially on amdgpu) — should be rendering in hardware, `DRM_IOCTL_PRIME_HANDLE_TO_FD` should be present without errors in the syscall trace