### PR TITLE
Fix issue #9 ("panic: <something>: called with spinlock or critical section held" on KabyLake)

### DIFF
--- a/drivers/gpu/drm/i915/i915_request.c
+++ b/drivers/gpu/drm/i915/i915_request.c
@@ -364,7 +364,7 @@ __i915_request_await_execution(struct i915_request *rq,
 	if (hook) {
 		cb->hook = hook;
 		cb->signal = i915_request_get(signal);
-#ifdef __linux__
+#if defined(__linux__) || (defined(__FreeBSD__) && __FreeBSD_version > 1300127)
 		cb->work.func = irq_execute_cb_hook;
 #elif defined(__FreeBSD__)
 		/* irq_work is just a workqueue for us */

--- a/drivers/gpu/drm/i915/i915_sw_fence.c
+++ b/drivers/gpu/drm/i915/i915_sw_fence.c
@@ -384,7 +384,11 @@ static void dma_i915_sw_fence_wake(struct dma_fence *dma,
 
 	i915_sw_fence_set_error_once(cb->fence, dma->error);
 	i915_sw_fence_complete(cb->fence);
+#if defined(__FreeBSD__) && __FreeBSD_version > 1300127
+	kfree_async(cb);
+#else
 	kfree(cb);
+#endif
 }
 
 static void timer_i915_sw_fence_wake(struct timer_list *t)

--- a/linuxkpi/gplv2/include/linux/llist.h
+++ b/linuxkpi/gplv2/include/linux/llist.h
@@ -1,3 +1,5 @@
+#include <sys/param.h>
+#if __FreeBSD_version < 1300128
 #ifndef _LINUX_GPLV2_LLIST_H
 #define _LINUX_GPLV2_LLIST_H
 /*
@@ -223,3 +225,6 @@ struct llist_node *llist_reverse_order(struct llist_node *head);
 
 #endif /* _LINUX_GPLV2_LLIST_H */
 
+#else
+#include_next <linux/llist.h>
+#endif

--- a/linuxkpi/gplv2/src/linux_llist.c
+++ b/linuxkpi/gplv2/src/linux_llist.c
@@ -1,3 +1,5 @@
+#include <sys/param.h>
+#if __FreeBSD_version < 1300128
 /*
  * Lock-less NULL terminated single linked list
  *
@@ -99,3 +101,4 @@ struct llist_node *llist_reverse_order(struct llist_node *head)
 
 	return new_head;
 }
+#endif


### PR DESCRIPTION
This fixes several panics triggered by running of fence callbacks in critical section.

It includes:
1. irq_work implementation via fast taskqueue: https://reviews.freebsd.org/D27171. Panic message is in review
2. SYSINIT initialization of current for irq_work thread as it can not be done lazily by i915kms without extra patching.
3. Asynchronous kfree() to use inside critical sections. This fixes panic from #9 

It is possible that p. 2 and 3 should belong to LKPI rather than to drm-kmod.