### PR TITLE
[5.4-lts] AMD DCN (Navi/Renoir) FPU fixes

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
@@ -2387,9 +2387,6 @@ bool dcn20_fast_validate_bw(
 	if (!pipes)
 		return false;
 
-#ifdef __FreeBSD__	
-	kernel_fpu_begin();
-#endif
 	/* merge previously split odm pipes since mode support needs to make the decision */
 	for (i = 0; i < dc->res_pool->pipe_count; i++) {
 		struct pipe_ctx *pipe = &context->res_ctx.pipe_ctx[i];
@@ -2885,9 +2882,6 @@ validate_fail:
 	out = false;
 
 validate_out:
-#ifdef __FreeBSD__
-	kernel_fpu_end();
-#endif	
 	kfree(pipes);
 
 	BW_VAL_TRACE_FINISH();
@@ -2903,22 +2897,27 @@ bool dcn20_validate_bandwidth(struct dc *dc, struct dc_state *context,
 	bool full_pstate_supported = false;
 	bool dummy_pstate_supported = false;
 #ifdef __FreeBSD__
+	double p_state_latency_us;
+
 	kernel_fpu_begin();
-#endif
+	p_state_latency_us = context->bw_ctx.dml.soc.dram_clock_change_latency_us;
+#else
 	double p_state_latency_us = context->bw_ctx.dml.soc.dram_clock_change_latency_us;
-#ifdef __FreeBSD__
-	kernel_fpu_end();
 #endif
 
-	if (fast_validate)
+	if (fast_validate) {
+#ifdef __FreeBSD__
+		voltage_supported = dcn20_validate_bandwidth_internal(dc, context, true);
+		kernel_fpu_end();
+		return voltage_supported;
+#else
 		return dcn20_validate_bandwidth_internal(dc, context, true);
+#endif
+	}
 
 
 	// Best case, we support full UCLK switch latency
 	voltage_supported = dcn20_validate_bandwidth_internal(dc, context, false);
-#ifdef __FreeBSD__
-	kernel_fpu_begin();
-#endif
 	full_pstate_supported = context->bw_ctx.bw.dcn.clk.p_state_change_support;
 
 	if (context->bw_ctx.dml.soc.dummy_pstate_latency_us == 0 ||
@@ -3463,6 +3462,10 @@ static bool construct(
 	enum dml_project dml_project_version =
 			get_dml_project_version(ctx->asic_id.hw_internal_rev);
 
+#ifdef __FreeBSD__
+	kernel_fpu_begin();
+#endif
+
 	ctx->dc_bios->regs = &bios_regs;
 	pool->base.funcs = &dcn20_res_pool_funcs;
 
@@ -3602,9 +3605,6 @@ static bool construct(
 
 			ranges.num_reader_wm_sets = 1;
 		} else if (loaded_bb->num_states > 1) {
-#ifdef __FreeBSD__
-			kernel_fpu_begin();
-#endif
 			for (i = 0; i < 4 && i < loaded_bb->num_states; i++) {
 				ranges.reader_wm_sets[i].wm_inst = i;
 				ranges.reader_wm_sets[i].min_drain_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MIN;
@@ -3615,9 +3615,6 @@ static bool construct(
 				ranges.num_reader_wm_sets = i + 1;
 			}
 
-#ifdef __FreeBSD__
-			kernel_fpu_end();
-#endif
 			ranges.reader_wm_sets[0].min_fill_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MIN;
 			ranges.reader_wm_sets[ranges.num_reader_wm_sets - 1].max_fill_clk_mhz = PP_SMU_WM_SET_RANGE_CLK_UNCONSTRAINED_MAX;
 		}
@@ -3756,10 +3753,16 @@ static bool construct(
 
 	dc->cap_funcs = cap_funcs;
 
+#ifdef __FreeBSD__
+	kernel_fpu_end();
+#endif
 	return true;
 
 create_fail:
 
+#ifdef __FreeBSD__
+	kernel_fpu_end();
+#endif
 	destruct(pool);
 
 	return false;

--- a/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
@@ -1063,6 +1063,9 @@ bool dcn21_validate_bandwidth(struct dc *dc, struct dc_state *context,
 		bool fast_validate)
 {
 	bool out = false;
+#ifdef __FreeBSD__
+	kernel_fpu_begin();
+#endif
 
 	BW_VAL_TRACE_SETUP();
 
@@ -1105,6 +1108,9 @@ validate_fail:
 
 validate_out:
 	kfree(pipes);
+#ifdef __FreeBSD__
+	kernel_fpu_end();
+#endif
 
 	BW_VAL_TRACE_FINISH();
 

--- a/linuxkpi/gplv2/include/asm/fpu/api.h
+++ b/linuxkpi/gplv2/include/asm/fpu/api.h
@@ -9,15 +9,20 @@
 #endif
 
 static struct fpu_kern_ctx *__fpu_ctx;
+static unsigned int __fpu_ctx_level = 0;
 
-#define	kernel_fpu_begin()			\
-	__fpu_ctx = fpu_kern_alloc_ctx(0);	\
-	fpu_kern_enter(curthread, __fpu_ctx,	\
-	    FPU_KERN_NORMAL);
+#define	kernel_fpu_begin()				\
+	if (__fpu_ctx_level++ == 0) {			\
+		__fpu_ctx = fpu_kern_alloc_ctx(0);	\
+		fpu_kern_enter(curthread, __fpu_ctx,	\
+		    FPU_KERN_NORMAL);			\
+	}
 
-#define	kernel_fpu_end()			\
-	fpu_kern_leave(curthread, __fpu_ctx);	\
-	fpu_kern_free_ctx(__fpu_ctx);
+#define	kernel_fpu_end()				\
+	if (--__fpu_ctx_level == 0) {			\
+		fpu_kern_leave(curthread, __fpu_ctx);	\
+		fpu_kern_free_ctx(__fpu_ctx);		\
+	}
 
 #endif /* _ASM_X86_FPU_API_H */
 #else


### PR DESCRIPTION
FPU fixes from #40 (tested on both Navi and Renoir at https://github.com/FreeBSDDesktop/kms-drm/issues/255) cherry-picked onto 5.4-lts.

Namely, this changes the fpu_begin/end calls to match the upstream ones https://github.com/torvalds/linux/commit/7a8a3430be15e4e6b3455f71853e7db765323889 (i.e. will be easy to switch to fully upstream code in 5.6) and makes our fpu_begin/end sections nestable.

Anyone with Navi or Renoir, please test! /cc @bcran @NorwegianRockCat @aiden-leong @DarkKirb @jiixyj @tsujp