### PR TITLE
LinuxKPI: firmware loading, devres, ... < 1400003

### DIFF
--- a/drivers/gpu/drm/drm_os_freebsd.h
+++ b/drivers/gpu/drm/drm_os_freebsd.h
@@ -104,6 +104,7 @@ do {								\
 	({ __typeof__(*(ptr)) __tmp;                                    \
 	  memcpy(&__tmp, (ptr), sizeof(*(ptr))); __tmp; })
 
+#if __FreeBSD_version < 1400003
 #if _BYTE_ORDER == _LITTLE_ENDIAN
 /* Taken from linux/include/linux/unaligned/le_struct.h. */
 struct __una_u32 { u32 x; } __packed;
@@ -137,6 +138,7 @@ get_unaligned_le32(const void *p)
 
 	return (__get_unaligned_le32((const u8 *)p));
 }
+#endif
 #endif
 
 #define	page_to_phys(x) VM_PAGE_TO_PHYS(x)

--- a/linuxkpi/gplv2/include/linux/device.h
+++ b/linuxkpi/gplv2/include/linux/device.h
@@ -7,6 +7,7 @@
 #include <linux/pm.h>
 #include <linux/idr.h>
 
+#if __FreeBSD_version < 1400003
 typedef void (*dr_release_t)(struct device *dev, void *res);
 typedef int (*dr_match_t)(struct device *dev, void *res, void *match_data);
 
@@ -264,5 +265,6 @@ devres_release_group(struct device *dev, void *id)
 
 	return cnt;
 }
+#endif
 
 #endif /* _LINUX_GPLV2_DEVICE_H_ */

--- a/linuxkpi/gplv2/include/linux/firmware.h
+++ b/linuxkpi/gplv2/include/linux/firmware.h
@@ -1,3 +1,5 @@
+#include <sys/param.h>
+#if __FreeBSD_version < 1400003
 #ifndef _LINUX_FIRMWARE_H
 #define _LINUX_FIRMWARE_H
 
@@ -49,4 +51,7 @@ int request_firmware_nowait(
 
 void release_firmware(const struct linux_firmware *fw);
 #define firmware linux_firmware
+#endif
+#else
+#include_next <linux/firmware.h>
 #endif

--- a/linuxkpi/gplv2/include/linux/kconfig.h
+++ b/linuxkpi/gplv2/include/linux/kconfig.h
@@ -1,3 +1,5 @@
+#include <sys/param.h>
+#if __FreeBSD_version < 1400003
 #ifndef __LINUX_KCONFIG_H
 #define __LINUX_KCONFIG_H
 #if 0
@@ -53,3 +55,4 @@
 	(IS_BUILTIN(option) || IS_MODULE(option))
 
 #endif /* __LINUX_KCONFIG_H */
+#endif

--- a/linuxkpi/gplv2/include/linux/kobject.h
+++ b/linuxkpi/gplv2/include/linux/kobject.h
@@ -3,6 +3,7 @@
 
 #include_next <linux/kobject.h>
 
+#if __FreeBSD_version < 1400003
 enum kobject_action {
 	KOBJ_ADD,
 	KOBJ_REMOVE,
@@ -22,5 +23,6 @@ kobject_uevent_env(struct kobject *kobj __unused,
 
 	return (0);
 }
+#endif
 
 #endif

--- a/linuxkpi/gplv2/include/linux/pci.h
+++ b/linuxkpi/gplv2/include/linux/pci.h
@@ -47,7 +47,9 @@ resource_contains(struct linux_resource *a, struct linux_resource *b)
 	return a->start <= b->start && a->end >= b->end;
 }
 
+#if __FreeBSD_version < 1400003
 void pci_dev_put(struct pci_dev *pdev);
+#endif
 
 static inline struct pci_dev *
 pci_upstream_bridge(struct pci_dev *dev)

--- a/linuxkpi/gplv2/include/linux/scatterlist.h
+++ b/linuxkpi/gplv2/include/linux/scatterlist.h
@@ -31,6 +31,7 @@
 
 #include_next <linux/scatterlist.h>
 
+#if __FreeBSD_version < 1400003
 static inline size_t
 sg_pcopy_from_buffer(struct scatterlist *sgl, unsigned int nents,
     const void *buf, size_t buflen, off_t offset)
@@ -68,6 +69,7 @@ sg_pcopy_from_buffer(struct scatterlist *sgl, unsigned int nents,
 	}
 	return (total);
 }
+#endif
 
 static inline size_t
 sg_copy_from_buffer(struct scatterlist *sgl, unsigned int nents,

--- a/linuxkpi/gplv2/include/linux/seqlock.h
+++ b/linuxkpi/gplv2/include/linux/seqlock.h
@@ -54,7 +54,9 @@ typedef struct seqcount {
 } seqcount_t;
 
 
+#if __FreeBSD_version < 1400003
 #define lockdep_init_map(a, b, c, d)
+#endif
 
 static inline void __seqcount_init(seqcount_t *s, const char *name,
 					  struct lock_class_key *key)

--- a/linuxkpi/gplv2/src/linux_device.c
+++ b/linuxkpi/gplv2/src/linux_device.c
@@ -3,6 +3,7 @@
 
 #undef resource
 
+#if __FreeBSD_version < 1400003
 static MALLOC_DEFINE(M_DEVRES, "devres", "Linux compat devres");
 
 static struct devres *
@@ -117,3 +118,4 @@ pci_dev_put(struct pci_dev *pdev)
 	free(pdev->bus, M_DEVBUF);
 	free(pdev, M_DEVBUF);
 }
+#endif

--- a/linuxkpi/gplv2/src/linux_firmware.c
+++ b/linuxkpi/gplv2/src/linux_firmware.c
@@ -1,4 +1,5 @@
 #include <sys/param.h>
+#if __FreeBSD_version < 1400003
 #include <sys/systm.h>
 #include <sys/kernel.h>
 #include <sys/linker.h>
@@ -121,3 +122,4 @@ release_firmware(const struct linux_firmware *lkfw)
 	free(__DECONST(void *, lkfw), M_LKPI_FW);
 	firmware_put(fw, 0);
 }
+#endif


### PR DESCRIPTION
Add __FreeBSD_version checks for various upcoming LinuxKPI
commits to head which are implemented in main.
The FreeBSD version may have to be updated depending on when
the commit can/will happen.

See: D26598, D28188, D28189, D27414