### PR TITLE
LinuxKPI: firmware loading, devres, ... < 1300139

### DIFF
--- a/drivers/gpu/drm/drm_os_freebsd.h
+++ b/drivers/gpu/drm/drm_os_freebsd.h
@@ -104,7 +104,8 @@ do {								\
 	({ __typeof__(*(ptr)) __tmp;                                    \
 	  memcpy(&__tmp, (ptr), sizeof(*(ptr))); __tmp; })
 
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 #if _BYTE_ORDER == _LITTLE_ENDIAN
 /* Taken from linux/include/linux/unaligned/le_struct.h. */
 struct __una_u32 { u32 x; } __packed;

--- a/linuxkpi/gplv2/include/linux/device.h
+++ b/linuxkpi/gplv2/include/linux/device.h
@@ -7,7 +7,8 @@
 #include <linux/pm.h>
 #include <linux/idr.h>
 
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 typedef void (*dr_release_t)(struct device *dev, void *res);
 typedef int (*dr_match_t)(struct device *dev, void *res, void *match_data);
 

--- a/linuxkpi/gplv2/include/linux/firmware.h
+++ b/linuxkpi/gplv2/include/linux/firmware.h
@@ -1,5 +1,6 @@
 #include <sys/param.h>
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 #ifndef _LINUX_FIRMWARE_H
 #define _LINUX_FIRMWARE_H
 

--- a/linuxkpi/gplv2/include/linux/kconfig.h
+++ b/linuxkpi/gplv2/include/linux/kconfig.h
@@ -1,5 +1,6 @@
 #include <sys/param.h>
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 #ifndef __LINUX_KCONFIG_H
 #define __LINUX_KCONFIG_H
 #if 0

--- a/linuxkpi/gplv2/include/linux/kobject.h
+++ b/linuxkpi/gplv2/include/linux/kobject.h
@@ -3,7 +3,8 @@
 
 #include_next <linux/kobject.h>
 
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 enum kobject_action {
 	KOBJ_ADD,
 	KOBJ_REMOVE,

--- a/linuxkpi/gplv2/include/linux/pci.h
+++ b/linuxkpi/gplv2/include/linux/pci.h
@@ -47,7 +47,8 @@ resource_contains(struct linux_resource *a, struct linux_resource *b)
 	return a->start <= b->start && a->end >= b->end;
 }
 
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 void pci_dev_put(struct pci_dev *pdev);
 #endif
 

--- a/linuxkpi/gplv2/include/linux/scatterlist.h
+++ b/linuxkpi/gplv2/include/linux/scatterlist.h
@@ -31,7 +31,8 @@
 
 #include_next <linux/scatterlist.h>
 
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 static inline size_t
 sg_pcopy_from_buffer(struct scatterlist *sgl, unsigned int nents,
     const void *buf, size_t buflen, off_t offset)

--- a/linuxkpi/gplv2/include/linux/seqlock.h
+++ b/linuxkpi/gplv2/include/linux/seqlock.h
@@ -54,7 +54,8 @@ typedef struct seqcount {
 } seqcount_t;
 
 
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 #define lockdep_init_map(a, b, c, d)
 #endif
 

--- a/linuxkpi/gplv2/src/linux_device.c
+++ b/linuxkpi/gplv2/src/linux_device.c
@@ -3,7 +3,8 @@
 
 #undef resource
 
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 static MALLOC_DEFINE(M_DEVRES, "devres", "Linux compat devres");
 
 static struct devres *

--- a/linuxkpi/gplv2/src/linux_firmware.c
+++ b/linuxkpi/gplv2/src/linux_firmware.c
@@ -1,5 +1,6 @@
 #include <sys/param.h>
-#if __FreeBSD_version < 1400003
+#if (__FreeBSD_version >= 1400000 && __FreeBSD_version < 1400003) || \
+    (__FreeBSD_version < 1300139)
 #include <sys/systm.h>
 #include <sys/kernel.h>
 #include <sys/linker.h>


### PR DESCRIPTION
Add __FreeBSD_version checks for the merge of various
upcoming LinuxKPts to stable/13.
This seems to build on main and stable/13 after the
__FreeBSD_version bump.