### PR TITLE
[5.4-lts] implement DRM_IOCTL_GET_PCIINFO, matching OpenBSD and DragonFly

### DIFF
--- a/drivers/gpu/drm/drm_internal.h
+++ b/drivers/gpu/drm/drm_internal.h
@@ -52,6 +52,10 @@ void drm_lastclose(struct drm_device *dev);
 /* drm_pci.c */
 int drm_irq_by_busid(struct drm_device *dev, void *data,
 		     struct drm_file *file_priv);
+#ifdef __FreeBSD__
+int drm_getpciinfo(struct drm_device *dev, void *data,
+		     struct drm_file *file_priv);
+#endif
 void drm_pci_agp_destroy(struct drm_device *dev);
 int drm_pci_set_busid(struct drm_device *dev, struct drm_master *master);
 

--- a/drivers/gpu/drm/drm_ioctl.c
+++ b/drivers/gpu/drm/drm_ioctl.c
@@ -613,7 +613,11 @@ static const struct drm_ioctl_desc drm_ioctls[] = {
 	DRM_IOCTL_DEF(DRM_IOCTL_UNBLOCK, drm_noop, DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY),
 	DRM_IOCTL_DEF(DRM_IOCTL_AUTH_MAGIC, drm_authmagic, DRM_MASTER),
 
+#ifdef __FreeBSD__
+	DRM_IOCTL_DEF(DRM_IOCTL_GET_PCIINFO, drm_getpciinfo, DRM_UNLOCKED|DRM_RENDER_ALLOW),
+#else
 	DRM_LEGACY_IOCTL_DEF(DRM_IOCTL_ADD_MAP, drm_legacy_addmap_ioctl, DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY),
+#endif
 	DRM_LEGACY_IOCTL_DEF(DRM_IOCTL_RM_MAP, drm_legacy_rmmap_ioctl, DRM_AUTH),
 
 	DRM_LEGACY_IOCTL_DEF(DRM_IOCTL_SET_SAREA_CTX, drm_legacy_setsareactx, DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY),

--- a/drivers/gpu/drm/drm_pci.c
+++ b/drivers/gpu/drm/drm_pci.c
@@ -286,6 +286,26 @@ int drm_irq_by_busid(struct drm_device *dev, void *data,
 	return drm_pci_irq_by_busid(dev, p);
 }
 
+#ifdef __FreeBSD__
+int
+drm_getpciinfo(struct drm_device *dev, void *data, struct drm_file *file_priv)
+{
+	struct drm_pciinfo *info = data;
+
+	info->domain = pci_get_domain(dev->dev->bsddev);
+	info->bus = pci_get_bus(dev->dev->bsddev);
+	info->dev = pci_get_slot(dev->dev->bsddev);
+	info->func = pci_get_function(dev->dev->bsddev);
+	info->vendor_id = pci_get_vendor(dev->dev->bsddev);
+	info->device_id = pci_get_device(dev->dev->bsddev);
+	info->subvendor_id = pci_get_subvendor(dev->dev->bsddev);
+	info->subdevice_id = pci_get_subdevice(dev->dev->bsddev);
+	info->revision_id = pci_get_revid(dev->dev->bsddev);
+
+	return 0;
+}
+#endif
+
 static void drm_pci_agp_init(struct drm_device *dev)
 {
 	if (drm_core_check_feature(dev, DRIVER_USE_AGP)) {

--- a/include/uapi/drm/drm.h
+++ b/include/uapi/drm/drm.h
@@ -720,6 +720,20 @@ struct drm_prime_handle {
 	__s32 fd;
 };
 
+#if defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD__)
+struct drm_pciinfo {
+	uint16_t	domain;
+	uint8_t		bus;
+	uint8_t		dev;
+	uint8_t		func;
+	uint16_t	vendor_id;
+	uint16_t	device_id;
+	uint16_t	subvendor_id;
+	uint16_t	subdevice_id;
+	uint8_t		revision_id;
+};
+#endif
+
 struct drm_syncobj_create {
 	__u32 handle;
 #define DRM_SYNCOBJ_CREATE_SIGNALED (1 << 0)
@@ -848,7 +862,11 @@ extern "C" {
 #define DRM_IOCTL_BLOCK			DRM_IOWR(0x12, struct drm_block)
 #define DRM_IOCTL_UNBLOCK		DRM_IOWR(0x13, struct drm_block)
 #define DRM_IOCTL_CONTROL		DRM_IOW( 0x14, struct drm_control)
+#if defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD__)
+#define DRM_IOCTL_GET_PCIINFO		DRM_IOR(0x15, struct drm_pciinfo)
+#else
 #define DRM_IOCTL_ADD_MAP		DRM_IOWR(0x15, struct drm_map)
+#endif
 #define DRM_IOCTL_ADD_BUFS		DRM_IOWR(0x16, struct drm_buf_desc)
 #define DRM_IOCTL_MARK_BUFS		DRM_IOW( 0x17, struct drm_buf_desc)
 #define DRM_IOCTL_INFO_BUFS		DRM_IOWR(0x18, struct drm_buf_info)


### PR DESCRIPTION
This API is used in libdrm for OpenBSD and DragonFly.

Adopting this API would allow making libdrm code simpler, as well as improve support for GPU usage in Capsicum capability mode (no need to do anything about hw.dri sysctls anymore).

ref: https://gitweb.dragonflybsd.org/dragonfly.git/commitdiff/8a697a22391bbafe215fab92a6cb29ed3a1f6edf

example libdrm patch (keeping backwards compatibility): https://github.com/DankBSD/ports/commit/85482d713db35679e03f55551fc000f33461739e