### PR TITLE
Switch to dummy vt backend in __remove_conflicting when needed

### DIFF
--- a/drm/Makefile
+++ b/drm/Makefile
@@ -147,6 +147,9 @@ SRCS+=	device_if.h \
 	pci_iov_if.h \
 	device_if.h \
 	iicbus_if.h \
+	opt_teken.h \
+	opt_splash.h \
+	opt_syscons.h \
 	opt_drm.h \
 	opt_vm.h \
 	opt_compat.h \


### PR DESCRIPTION
AMD drivers use the remove_conflicting_pci_framebuffers function to kick the EFI framebuffer out early, to prevent it from messing with VRAM, corrupting things used by the driver loading process.

Our implementation could not actually remove native vt drivers, only LinuxKPI registered ones.

This commit solves the amdgpu/radeon efifb conflict, i.e. fixes #60

---

<details>
<summary>example dmesg log</summary>

```
[4] <6>[drm] amdgpu kernel modesetting enabled.
[4] drmn0: <drmn> on vgapci0
[4] VT: Replacing driver "efifb" with new "dummy".
[4] vgapci0: child drmn0 requested pci_enable_io
[4] vgapci0: child drmn0 requested pci_enable_io
[4] sysctl_warn_reuse: can't re-use a leaf (hw.dri.debug)!
[4] <6>[drm] initializing kernel modesetting (VEGA10 0x1002:0x687F 0x1002:0x6B76 0xC1).
[4] <6>[drm] register mmio base: 0xFCD00000
[4] <6>[drm] register mmio size: 524288
[4] <6>[drm] add ip block number 0 <soc15_common>
[4] <6>[drm] add ip block number 1 <gmc_v9_0>
[4] <6>[drm] add ip block number 2 <vega10_ih>
[4] <6>[drm] add ip block number 3 <psp>
[4] <6>[drm] add ip block number 4 <gfx_v9_0>
[4] <6>[drm] add ip block number 5 <sdma_v4_0>
[4] <6>[drm] add ip block number 6 <powerplay>
[4] <6>[drm] add ip block number 7 <dm>
[4] <6>[drm] add ip block number 8 <uvd_v7_0>
[4] <6>[drm] add ip block number 9 <vce_v4_0>
[4] drmn0: successfully loaded firmware image 'amdgpu/vega10_gpu_info.bin'
[4] ATOM BIOS: 113-D0500100-102
[4] drmn0: successfully loaded firmware image 'amdgpu/vega10_sdma.bin'
[4] drmn0: successfully loaded firmware image 'amdgpu/vega10_sdma1.bin'
[4] <6>[drm] UVD(0) is enabled in VM mode
[4] <6>[drm] UVD(0) ENC is enabled in VM mode
[4] <6>[drm] VCE enabled in VM mode
[4] <6>[drm] vm size is 262144 GB, 4 levels, block size is 9-bit, fragment size is 9-bit
[4] drmn0: VRAM: 8176M 0x000000F400000000 - 0x000000F5FEFFFFFF (8176M used)
[4] drmn0: GART: 512M 0x0000000000000000 - 0x000000001FFFFFFF
[4] drmn0: AGP: 267419648M 0x000000F800000000 - 0x0000FFFFFFFFFFFF
[4] Successfully added WC MTRR for [0x7c00000000-0x7dffffffff]: 0;
[4] <6>[drm] Detected VRAM RAM=8176M, BAR=8192M
[4] <6>[drm] RAM width 2048bits HBM
[4] [TTM] Zone  kernel: Available graphics memory: 33497204 KiB
[4] [TTM] Zone   dma32: Available graphics memory: 2097152 KiB
[4] [TTM] Initializing pool allocator
[5] <6>[drm] amdgpu: 8176M of VRAM memory ready
[5] <6>[drm] amdgpu: 8176M of GTT memory ready.
[5] <6>[drm] GART: num cpu pages 131072, num gpu pages 131072
[5] <6>[drm] PCIE GART of 512M enabled (table at 0x000000F400900000).
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_sos.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_asd.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_pfp.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_me.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_ce.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_rlc.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_mec.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_mec2.bin'
[5] <6>[drm] use_doorbell being set to: [true]
[5] <6>[drm] use_doorbell being set to: [true]
[5] amdgpu: [powerplay] hwmgr_sw_init smu backed is vega10_smu
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_acg_smc.bin'
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_uvd.bin'
[5] <6>[drm] Found UVD firmware Version: 66.43 Family ID: 17
[5] <6>[drm] PSP loading UVD firmware
[5] drmn0: successfully loaded firmware image 'amdgpu/vega10_vce.bin'
[5] <6>[drm] Found VCE firmware Version: 57.6 Binary ID: 4
[5] <6>[drm] PSP loading VCE firmware
[5] <6>[drm] reserve 0x400000 from 0xf5fe800000 for PSP TMR
[5] <6>[drm] Display Core initialized with v3.2.48!
[5] <6>[drm] Connector DP-1: get mode from tunables:
[5] <6>[drm]   - kern.vt.fb.modes.DP-1
[5] <6>[drm]   - kern.vt.fb.default_mode
[5] <6>[drm] Connector DP-2: get mode from tunables:
[5] <6>[drm]   - kern.vt.fb.modes.DP-2
[5] <6>[drm]   - kern.vt.fb.default_mode
[5] <6>[drm] Connector DP-3: get mode from tunables:
[5] <6>[drm]   - kern.vt.fb.modes.DP-3
[5] <6>[drm]   - kern.vt.fb.default_mode
[5] <6>[drm] Connector HDMI-A-1: get mode from tunables:
[5] <6>[drm]   - kern.vt.fb.modes.HDMI-A-1
[5] <6>[drm]   - kern.vt.fb.default_mode
[5] <6>[drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
[5] <6>[drm] Driver supports precise vblank timestamp query.
[5] <6>[drm] UVD and UVD ENC initialized successfully.
[5] <6>[drm] VCE initialized successfully.
[5] <6>[drm] fb mappable at 0x7C00CEE000
[5] <6>[drm] vram apper at 0x7C00000000
[5] <6>[drm] size 14745600
[5] <6>[drm] fb depth is 24
[5] <6>[drm]    pitch is 10240
[5] WARNING: Device "fb" is Giant locked and may be deleted before FreeBSD 14.0.
[5] VT: Replacing driver "dummy" with new "fb".
[5] start FB_INFO:
[5] type=11 height=1440 width=2560 depth=32
[5] cmsize=16 size=14745600
[5] pbase=0x7c00cee000 vbase=0xfffffe01ca0ee000
[5] name=drmn0 flags=0x0 stride=10240 bpp=32
[5] cmap[0]=191919 cmap[1]=f2005e cmap[2]=96dd23 cmap[3]=fc961e
[5] end FB_INFO
[5] drmn0: fb0: amdgpudrmfb frame buffer device
[5] drmn0: ring gfx uses VM inv eng 0 on hub 0
[5] drmn0: ring comp_1.0.0 uses VM inv eng 1 on hub 0
[5] drmn0: ring comp_1.1.0 uses VM inv eng 4 on hub 0
[5] drmn0: ring comp_1.2.0 uses VM inv eng 5 on hub 0
[5] drmn0: ring comp_1.3.0 uses VM inv eng 6 on hub 0
[5] drmn0: ring comp_1.0.1 uses VM inv eng 7 on hub 0
[5] drmn0: ring comp_1.1.1 uses VM inv eng 8 on hub 0
[5] drmn0: ring comp_1.2.1 uses VM inv eng 9 on hub 0
[5] drmn0: ring comp_1.3.1 uses VM inv eng 10 on hub 0
[5] drmn0: ring kiq_2.1.0 uses VM inv eng 11 on hub 0
[5] drmn0: ring sdma0 uses VM inv eng 0 on hub 1
[5] drmn0: ring page0 uses VM inv eng 1 on hub 1
[5] drmn0: ring sdma1 uses VM inv eng 4 on hub 1
[5] drmn0: ring page1 uses VM inv eng 5 on hub 1
[5] drmn0: ring uvd_0 uses VM inv eng 6 on hub 1
[5] drmn0: ring uvd_enc_0.0 uses VM inv eng 7 on hub 1
[5] drmn0: ring uvd_enc_0.1 uses VM inv eng 8 on hub 1
[5] drmn0: ring vce0 uses VM inv eng 9 on hub 1
[5] drmn0: ring vce1 uses VM inv eng 10 on hub 1
[5] drmn0: ring vce2 uses VM inv eng 11 on hub 1
[5] <6>[drm] ECC is not present.
[5] <6>[drm] SRAM ECC is not present.
[5] <6>[drm] Initialized amdgpu 3.35.0 20150101 for drmn0 on minor 0
```

</details>


btw I don't like the fact that priorities are checked when doing `vt_allocate` >_< This patch might change something about what happens when unloading the driver. (IIRC, unloading amdgpu didn't restore EFI framebuffer anyway?)