### PR TITLE
Allow drm-kmod to build with LINT

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/atom.c
+++ b/drivers/gpu/drm/amd/amdgpu/atom.c
@@ -86,6 +86,9 @@ static int atom_dst_to_src[8][4] = {
 };
 static int atom_def_dst[8] = { 0, 0, 1, 2, 0, 1, 2, 3 };
 
+#ifdef DEBUG
+#undef DEBUG
+#endif
 static int debug_depth = 0;
 #ifdef ATOM_DEBUG
 static void debug_print_spaces(int n)

--- a/drivers/gpu/drm/drm_print.c
+++ b/drivers/gpu/drm/drm_print.c
@@ -23,7 +23,9 @@
  * Rob Clark <robdclark@gmail.com>
  */
 
+#ifndef	DEBUG
 #define DEBUG /* for pr_debug() */
+#endif
 
 #ifdef __FreeBSD__
 #include <machine/stdarg.h>

--- a/drivers/gpu/drm/i915/gem/i915_gem_execbuffer.c
+++ b/drivers/gpu/drm/i915/gem/i915_gem_execbuffer.c
@@ -1454,7 +1454,7 @@ static int eb_relocate_vma(struct i915_execbuffer *eb, struct i915_vma *vma)
 	struct drm_i915_gem_relocation_entry stack[N_RELOC(512)];
 	struct drm_i915_gem_relocation_entry __user *urelocs;
 	const struct drm_i915_gem_exec_object2 *entry = exec_entry(eb, vma);
-	unsigned int remain;
+	uintmax_t remain;
 
 	urelocs = u64_to_user_ptr(entry->relocs_ptr);
 	remain = entry->relocation_count;

--- a/drivers/gpu/drm/i915/i915_trace_freebsd.h
+++ b/drivers/gpu/drm/i915/i915_trace_freebsd.h
@@ -368,7 +368,7 @@ trace_g4x_wm(void *crtc, void *wm)
 static inline void
 trace_vlv_fifo_size(void *crtc, uint32_t sprite0_start, uint32_t sprite1_start, uint32_t fifo_size)
 {
-	CTR4(KTR_DRM, "vlv_fifo_size crtc %p sprite0_start %x, sprite1_start %x, fifo_size %x", crtc, sprite0_start, sprite1_start, fifi_size);
+	CTR4(KTR_DRM, "vlv_fifo_size crtc %p sprite0_start %x, sprite1_start %x, fifo_size %x", crtc, sprite0_start, sprite1_start, fifo_size);
 }
 
 #endif /* _I915_TRACE_H_ */

--- a/drivers/gpu/drm/radeon/atom.c
+++ b/drivers/gpu/drm/radeon/atom.c
@@ -89,6 +89,9 @@ static int atom_dst_to_src[8][4] = {
 };
 static int atom_def_dst[8] = { 0, 0, 1, 2, 0, 1, 2, 3 };
 
+#ifdef DEBUG
+#undef DEBUG
+#endif
 static int debug_depth = 0;
 #ifdef ATOM_DEBUG
 static void debug_print_spaces(int n)

--- a/drivers/gpu/drm/tainted_linux_fb.c
+++ b/drivers/gpu/drm/tainted_linux_fb.c
@@ -1006,7 +1006,9 @@ tainted_cfb_copyarea(struct linux_fb_info *p, const struct fb_copyarea *area)
 	}
 }
 
+#ifndef DEBUG
 #define DEBUG
+#endif
 
 #ifdef DEBUG
 #define DPRINTK(fmt, args...) printk(KERN_DEBUG "%s: " fmt,__func__,## args)

--- a/linuxkpi/gplv2/include/trace/events/dma_fence.h
+++ b/linuxkpi/gplv2/include/trace/events/dma_fence.h
@@ -2,6 +2,9 @@
 #define _TRACE_DMA_FENCE_H_
 
 #include <linux/dma-fence.h>
+#ifndef KTR_DRM
+#define	KTR_DRM	KTR_DEV
+#endif
 
 /* trace_dma_fence_enable_signal(&rq->fence); */
 static inline void


### PR DESCRIPTION
Hide various #define DEBUG statements under #ifndef DEBUG to not re-define
DEBUG, or make sure DEBUG is not defined before we define DEBUG(...).

Also make sure KTR_DRM is always defined and fix a typo in one CTR4().

Further extend the size of a variable to check against a larger constant
value (which otherwise would always fail in error).

With this drm-kmod also builds along LINT kernels, which makes it easier
to test other changes.

Sponsored-by:	The FreeBSD Foundation