### PR TITLE
Fix another one instance of "acquiring blockable sleep lock

### DIFF
--- a/drivers/gpu/drm/i915/i915_drv.h
+++ b/drivers/gpu/drm/i915/i915_drv.h
@@ -1499,7 +1499,13 @@ struct drm_i915_private {
 
 	struct intel_atomic_helper {
 		struct llist_head free_list;
+#ifdef __linux__
 		struct work_struct free_work;
+#elif defined (__FreeBSD__)
+		/* On FreeBSD this work is sporadically scheduled
+		 * within a critical section. */
+		struct irq_work free_work;
+#endif
 	} atomic_helper;
 
 	u16 orig_clock;

--- a/linuxkpi/gplv2/include/asm/processor.h
+++ b/linuxkpi/gplv2/include/asm/processor.h
@@ -69,9 +69,15 @@ struct cpuinfo_x86 {
 #define	rmb()	__asm __volatile("lfence;" : : : "memory")
 #endif
 
+#ifndef smp_mb
 #define smp_mb() mb()
+#endif
+#ifndef smp_wmb
 #define smp_wmb() wmb()
+#endif
+#ifndef smp_rmb
 #define smp_rmb() rmb()
+#endif
 
 static __always_inline void cpu_relax(void)
 {


### PR DESCRIPTION
with spinlock or critical section held" assertion on Intel Kaby Lake GPU
(Issue #9) with replacment of work_struct with its critical section-friendly
variant called irq_work.

The panic message is:

panic: acquiring blockable sleep lock with spinlock or critical section held (sleep mutex) linux_wq_exec @ /usr/src/sys/compat/linuxkpi/common/src/linux_work.c:105
cpuid = 3
time = 1617926020
KDB: stack backtrace:
db_trace_self_wrapper() at db_trace_self_wrapper+0x2b/frame 0xfffffe00da4e6010
vpanic() at vpanic+0x181/frame 0xfffffe00da4e6060
panic() at panic+0x43/frame 0xfffffe00da4e60c0
witness_checkorder() at witness_checkorder+0xf3e/frame 0xfffffe00da4e6280
__mtx_lock_flags() at __mtx_lock_flags+0x94/frame 0xfffffe00da4e62d0
linux_queue_work_on() at linux_queue_work_on+0x9a/frame 0xfffffe00da4e6310
intel_atomic_commit_ready() at intel_atomic_commit_ready+0x55/frame 0xfffffe00da4e6320
__i915_sw_fence_complete() at __i915_sw_fence_complete+0x188/frame 0xfffffe00da4e6370
dma_i915_sw_fence_wake_timer() at dma_i915_sw_fence_wake_timer+0x27/frame 0xfffffe00da4e6390
dma_fence_signal() at dma_fence_signal+0xc0/frame 0xfffffe00da4e63e0
dma_resv_add_shared_fence() at dma_resv_add_shared_fence+0xa6/frame 0xfffffe00da4e6430
i915_vma_move_to_active() at i915_vma_move_to_active+0x6b/frame 0xfffffe00da4e6470
i915_gem_do_execbuffer() at i915_gem_do_execbuffer+0x1414/frame 0xfffffe00da4e6680
i915_gem_execbuffer2_ioctl() at i915_gem_execbuffer2_ioctl+0x185/frame 0xfffffe00da4e66e0
drm_ioctl_kernel() at drm_ioctl_kernel+0x72/frame 0xfffffe00da4e6730
drm_ioctl() at drm_ioctl+0x2c8/frame 0xfffffe00da4e6820
linux_file_ioctl() at linux_file_ioctl+0x31d/frame 0xfffffe00da4e6880
kern_ioctl() at kern_ioctl+0x1ef/frame 0xfffffe00da4e68f0
sys_ioctl() at sys_ioctl+0x12a/frame 0xfffffe00da4e69c0
amd64_syscall() at amd64_syscall+0x124/frame 0xfffffe00da4e6af0
fast_syscall_common() at fast_syscall_common+0xf8/frame 0xfffffe00da4e6af0
--- syscall (54, FreeBSD ELF64, sys_ioctl), rip = 0x800a7188a, rsp = 0x7fffffffe2a8, rbp = 0x7fffffffe360 ---
KDB: enter: panic