### PR TITLE
Update checks for __FreeBSD_version[1] after MFCs to stable/13 were d…

### DIFF
--- a/linuxkpi/gplv2/include/linux/cpu.h
+++ b/linuxkpi/gplv2/include/linux/cpu.h
@@ -2,7 +2,7 @@
 #define	__GPLV2_LINUX_CPU_H
 #include <sys/param.h>
 #if (__FreeBSD_version >= 1400015) || \
-    ((__FreeBSD_version < 1400000) && (__FreeBSD_version >= 1399999))
+    ((__FreeBSD_version < 1400000) && (__FreeBSD_version >= 1300512))
 #include_next <linux/cpu.h>
 #endif
 #endif

--- a/linuxkpi/gplv2/include/linux/stringify.h
+++ b/linuxkpi/gplv2/include/linux/stringify.h
@@ -2,7 +2,7 @@
 #define	__GPLV2_LINUX_STRINGIFY_H
 #include <sys/param.h>
 #if (__FreeBSD_version >= 1400015) || \
-    ((__FreeBSD_version < 1400000) && (__FreeBSD_version >= 1399999))
+    ((__FreeBSD_version < 1400000) && (__FreeBSD_version >= 1300512))
 #include_next <linux/stringify.h>
 #endif
 #endif


### PR DESCRIPTION
…one.

[1] ((__FreeBSD_version < 1400000) && (__FreeBSD_version >= 1300512))