### PR TITLE
[5.5-stable] Fix malloc-in-FPU-section

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
@@ -2992,7 +2992,14 @@ static bool dcn20_validate_bandwidth_internal(struct dc *dc, struct dc_state *co
 	int vlevel = 0;
 	int pipe_split_from[MAX_PIPES];
 	int pipe_cnt = 0;
+	// BSDFIXME: keeping alloc/free out of the critical section due to aggressive INVARIANTS
+#ifdef __FreeBSD__
+	kernel_fpu_end();
+#endif
 	display_e2e_pipe_params_st *pipes = kzalloc(dc->res_pool->pipe_count * sizeof(display_e2e_pipe_params_st), GFP_KERNEL);
+#ifdef __FreeBSD__
+	kernel_fpu_begin();
+#endif
 	DC_LOGGER_INIT(dc->ctx->logger);
 
 	BW_VAL_TRACE_COUNT();
@@ -3027,7 +3034,14 @@ validate_fail:
 	out = false;
 
 validate_out:
+	// BSDFIXME: keeping alloc/free out of the critical section due to aggressive INVARIANTS
+#ifdef __FreeBSD__
+	kernel_fpu_end();
+#endif
 	kfree(pipes);
+#ifdef __FreeBSD__
+	kernel_fpu_begin();
+#endif
 
 	BW_VAL_TRACE_FINISH();
 

--- a/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
@@ -1144,9 +1144,6 @@ bool dcn21_validate_bandwidth(struct dc *dc, struct dc_state *context,
 		bool fast_validate)
 {
 	bool out = false;
-#ifdef __FreeBSD__
-	kernel_fpu_begin();
-#endif
 
 	BW_VAL_TRACE_SETUP();
 
@@ -1154,6 +1151,10 @@ bool dcn21_validate_bandwidth(struct dc *dc, struct dc_state *context,
 	int pipe_split_from[MAX_PIPES];
 	int pipe_cnt = 0;
 	display_e2e_pipe_params_st *pipes = kzalloc(dc->res_pool->pipe_count * sizeof(display_e2e_pipe_params_st), GFP_KERNEL);
+#ifdef __FreeBSD__
+	// BSDFIXME: keeping alloc/free out of the critical section due to aggressive INVARIANTS
+	kernel_fpu_begin();
+#endif
 	DC_LOGGER_INIT(dc->ctx->logger);
 
 	BW_VAL_TRACE_COUNT();
@@ -1188,10 +1189,11 @@ validate_fail:
 	out = false;
 
 validate_out:
-	kfree(pipes);
 #ifdef __FreeBSD__
+	// BSDFIXME: keeping alloc/free out of the critical section due to aggressive INVARIANTS
 	kernel_fpu_end();
 #endif
+	kfree(pipes);
 
 	BW_VAL_TRACE_FINISH();
 


### PR DESCRIPTION
This should fix #101 on 5.5-stable hopefully?

Since https://reviews.freebsd.org/D29921 our FPU sections are critical sections (`NOCTX`) as they are on Linux, and our `INVARIANTS` caught the waiting-malloc-under-critical-section issue that was only found by the Linux developers *several* releases later. (dcn20 in 5.9, and then dcn21 in 5.12 — actually dcn21 has just been [left *without* an FPU block (!) until then](https://github.com/torvalds/linux/commit/41401ac67791810dd880345962339aa1bedd3c0d))

ARGH WHY IS LINUX SO SLOPPY WITH THE FPU STUFF