### PR TITLE
Add RISC-V support and fix powerpc64 detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ SUPPORTED_ARCH=	amd64 \
 		i386 \
 		aarch64 \
 		powerpc64 \
-		powerpc64le
+		powerpc64le \
+		riscv64 \
+		riscv64sf
 
 .if empty(SUPPORTED_ARCH:M${MACHINE_ARCH})
 .error "Unsupported architetures ${MACHINE_ARCH}"

--- a/amd/Makefile
+++ b/amd/Makefile
@@ -1,6 +1,13 @@
 # $FreeBSD$
 
-.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_ARCH} == "powerpc64" || ${MACHINE_ARCH} == "powerpc64le"
+AMDGPU_ARCH=	amd64 \
+		aarch64 \
+		powerpc64 \
+		powerpc64le \
+		riscv64 \
+		riscv64sf
+
+.if !empty(AMDGPU_ARCH:M${MACHINE_ARCH})
 _amdgpu=	amdgpu
 .endif
 

--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -629,7 +629,11 @@ __register_framebuffer(struct linux_fb_info *fb_info)
 	vm_phys_fictitious_reg_range(fb_info->apertures->ranges[0].base,
 				     fb_info->apertures->ranges[0].base +
 				     fb_info->apertures->ranges[0].size,
+#ifdef VM_MEMATTR_WRITE_COMBINING
 				     VM_MEMATTR_WRITE_COMBINING);
+#else
+				     VM_MEMATTR_UNCACHEABLE);
+#endif
 	fb_info->dev = device_create(fb_class, fb_info->device,
 				     MKDEV(FB_MAJOR, i), NULL, "fb%d", i);
 	if (IS_ERR(fb_info->dev)) {

--- a/kconfig.mk
+++ b/kconfig.mk
@@ -68,3 +68,11 @@ KCONFIG+=	DRM_AMD_DC_DCN \
 KCONFIG+=	64BIT \
 		PPC64
 .endif
+
+.if ${MACHINE_CPUARCH} == "riscv"
+KCONFIG+=	RISCV
+
+.if !empty(${MACHINE_ARCH:Mriscv64*})
+KCONFIG+=	64BIT
+.endif
+.endif

--- a/kconfig.mk
+++ b/kconfig.mk
@@ -64,7 +64,7 @@ KCONFIG+=	DRM_AMD_DC_DCN \
 .endif
 .endif
 
-.if ${MACHINE_CPUARCH} == "powerpc64"
+.if !empty(${MACHINE_ARCH:Mpowerpc64*})
 KCONFIG+=	64BIT \
 		PPC64
 .endif

--- a/linuxkpi/gplv2/include/asm/set_memory.h
+++ b/linuxkpi/gplv2/include/asm/set_memory.h
@@ -40,7 +40,11 @@ set_memory_uc(unsigned long addr, int numpages)
 static inline int
 set_memory_wc(unsigned long addr, int numpages)
 {
+#ifdef VM_MEMATTR_WRITE_COMBINING
 	return (pmap_change_attr(addr, numpages, VM_MEMATTR_WRITE_COMBINING));
+#else
+	return (set_memory_uc(addr, numpages));
+#endif
 }
 
 static inline int
@@ -63,7 +67,11 @@ set_pages_wc(vm_page_t page, int numpages)
 {
 	KASSERT(numpages == 1, ("%s: numpages %d", __func__, numpages));
 
+#ifdef VM_MEMATTR_WRITE_COMBINING
 	pmap_page_set_memattr(page, VM_MEMATTR_WRITE_COMBINING);
+#else
+	return (set_pages_uc(page, numpages));
+#endif
 	return (0);
 }
 

--- a/linuxkpi/gplv2/include/linux/io.h
+++ b/linuxkpi/gplv2/include/linux/io.h
@@ -5,7 +5,7 @@
 
 #include_next <linux/io.h>
  
-#if defined(__amd64__) || defined(__i386__) || defined(__aarch64__) || defined(__powerpc__)
+#if defined(__amd64__) || defined(__i386__) || defined(__aarch64__) || defined(__powerpc__) || defined(__riscv)
 static inline int
 arch_io_reserve_memtype_wc(resource_size_t start, resource_size_t size)
 {

--- a/linuxkpi/gplv2/include/linux/irq.h
+++ b/linuxkpi/gplv2/include/linux/irq.h
@@ -15,7 +15,7 @@
 
 #include <asm/processor.h>
 
-#if defined(__i386__) || defined(__amd64__) || defined(__aarch64__) || defined(__powerpc__)
+#if defined(__i386__) || defined(__amd64__) || defined(__aarch64__) || defined(__powerpc__) || defined(__riscv)
 #define NR_IRQS	512 /* XXX need correct value */
 #else
 #error "NR_IRQS not defined"


### PR DESCRIPTION
No clue if it actually works as I have yet to plug a GPU into my Unmatched board, but this gets it building.

NB: Depends on D31996 and D31999