### PR TITLE
Fix build after 1400037

### DIFF
--- a/drivers/dma-buf/dma-buf.c
+++ b/drivers/dma-buf/dma-buf.c
@@ -118,8 +118,13 @@ dma_buf_close(struct file *fp, struct thread *td)
 }
 
 static int
+#if __FreeBSD_version < 1400037
 dma_buf_stat(struct file *fp, struct stat *sb,
 	     struct ucred *active_cred __unused, struct thread *td __unused)
+#else
+dma_buf_stat(struct file *fp, struct stat *sb,
+	     struct ucred *active_cred __unused)
+#endif
 {
 
 	/* XXX need to define flags for st_mode */


### PR DESCRIPTION
The following commit removed thread argument from fo_stat.

https://cgit.freebsd.org/src/commit/?id=2b68eb8e1dbbdaf6a0df1c83b26f5403ca52d4c3

This fix is required for graphics/drm-{current,devel}-kmod.