### PR TITLE
dma_buf.c: Catch up to FreeBSD main/2b68eb8e1dbbdaf6a0df1c83b26f5403c…

### DIFF
--- a/drivers/dma-buf/dma-buf.c
+++ b/drivers/dma-buf/dma-buf.c
@@ -119,7 +119,7 @@ dma_buf_close(struct file *fp, struct thread *td)
 
 static int
 dma_buf_stat(struct file *fp, struct stat *sb,
-	     struct ucred *active_cred __unused, struct thread *td __unused)
+	     struct ucred *active_cred __unused)
 {
 
 	/* XXX need to define flags for st_mode */


### PR DESCRIPTION
…a52d4c3

FreeBSD 2b68eb8e1dbbdaf6a0df1c83b26f5403ca52d4c3 removed the thread
argument from VOP_STAT and fo_stat. This fixes drm-current-kmod build
following FreeBSD 2b68eb8e1dbbdaf6a0df1c83b26f5403ca52d4c3.

Signed-off by:	Cy Schubert <cy@FreeBSD.org>