### PR TITLE
Attempt to fix 3da42da6111 breaking suspend/resume on whiskeylake

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_display.c
+++ b/drivers/gpu/drm/i915/display/intel_display.c
@@ -15269,11 +15269,7 @@ static void intel_atomic_helper_free_state(struct drm_i915_private *dev_priv)
 		drm_atomic_state_put(&state->base);
 }
 
-#ifdef __linux__
 static void intel_atomic_helper_free_state_worker(struct work_struct *work)
-#elif defined (__FreeBSD__)
-static void intel_atomic_helper_free_state_worker(struct irq_work *work)
-#endif
 {
 	struct drm_i915_private *dev_priv =
 		container_of(work, typeof(*dev_priv), atomic_helper.free_work);
@@ -15516,11 +15512,7 @@ intel_atomic_commit_ready(struct i915_sw_fence *fence,
 				&to_i915(state->base.dev)->atomic_helper;
 
 			if (llist_add(&state->freed, &helper->free_list))
-#ifdef __linux__
 				schedule_work(&helper->free_work);
-#elif defined (__FreeBSD__)
-				irq_work_queue(&helper->free_work);
-#endif
 			break;
 		}
 	}
@@ -17562,13 +17554,8 @@ int intel_modeset_init(struct drm_i915_private *i915)
 		return ret;
 
 	init_llist_head(&i915->atomic_helper.free_list);
-#ifdef __linux__
 	INIT_WORK(&i915->atomic_helper.free_work,
 		  intel_atomic_helper_free_state_worker);
-#elif defined (__FreeBSD__)
-	init_irq_work(&i915->atomic_helper.free_work,
-		      intel_atomic_helper_free_state_worker);
-#endif
 
 	intel_init_quirks(i915);
 
@@ -18504,11 +18491,7 @@ void intel_modeset_driver_remove(struct drm_i915_private *i915)
 	flush_workqueue(i915->flip_wq);
 	flush_workqueue(i915->modeset_wq);
 
-#ifdef __linux__
 	flush_work(&i915->atomic_helper.free_work);
-#elif defined (__FreeBSD__)
-	irq_work_sync(&i915->atomic_helper.free_work);
-#endif
 	WARN_ON(!llist_empty(&i915->atomic_helper.free_list));
 
 	/*

--- a/drivers/gpu/drm/i915/i915_drv.h
+++ b/drivers/gpu/drm/i915/i915_drv.h
@@ -1120,13 +1120,7 @@ struct drm_i915_private {
 
 	struct intel_atomic_helper {
 		struct llist_head free_list;
-#ifdef __linux__
 		struct work_struct free_work;
-#elif defined (__FreeBSD__)
-		/* On FreeBSD this work is sporadically scheduled
-		 * within a critical section. */
-		struct irq_work free_work;
-#endif
 	} atomic_helper;
 
 	u16 orig_clock;


### PR DESCRIPTION
Test conducted shows that we can skip scheduling of free_work in critical section as intel_atomic_helper_free_state() will be called very soon from another safe code path.

Reported by @evadot via gitter.im
