### PR TITLE
dma-buf: Do not disable preemption in dma_resv_add_shared_fence

### DIFF
--- a/drivers/dma-buf/dma-fence.c
+++ b/drivers/dma-buf/dma-fence.c
@@ -176,17 +176,6 @@ int dma_fence_signal(struct dma_fence *fence)
 	if (!fence)
 		return -EINVAL;
 
-#ifdef __FreeBSD__
-	/*
-	 * Avoid blocking on fence lock within a critical section. It is safe
-	 * to exit from critical section if trylock is failed and use
-	 * ordinary spin_lock() after than, but current code is simpler.
-	 */
-	if (curthread->td_critnest != 0)
-		while (!spin_trylock_irqsave(fence->lock, flags))
-			{}
-	else
-#endif
 	spin_lock_irqsave(fence->lock, flags);
 	ret = dma_fence_signal_locked(fence);
 	spin_unlock_irqrestore(fence->lock, flags);

--- a/drivers/gpu/drm/i915/display/intel_display.c
+++ b/drivers/gpu/drm/i915/display/intel_display.c
@@ -15706,9 +15706,6 @@ intel_atomic_commit_ready(struct i915_sw_fence *fence,
 				&to_i915(state->base.dev)->atomic_helper;
 
 			if (llist_add(&state->freed, &helper->free_list))
-#ifdef __FreeBSD__
-			    if (curthread->td_critnest == 0)
-#endif
 				schedule_work(&helper->free_work);
 			break;
 		}
@@ -18771,12 +18768,7 @@ void intel_modeset_driver_remove(struct drm_i915_private *i915)
 	flush_workqueue(i915->modeset_wq);
 
 	flush_work(&i915->atomic_helper.free_work);
-#ifdef __linux__
 	drm_WARN_ON(&i915->drm, !llist_empty(&i915->atomic_helper.free_list));
-#elif defined(__FreeBSD__)
-	/* schedule_work() can be skipped if called from critical section */
-	intel_atomic_helper_free_state(i915);
-#endif
 }
 
 /* part #2: call after irq uninstall */

--- a/drivers/gpu/drm/i915/i915_active.c
+++ b/drivers/gpu/drm/i915/i915_active.c
@@ -161,11 +161,7 @@ __active_retire(struct i915_active *ref)
 }
 
 static void
-#ifdef __linux__
 active_work(struct work_struct *wrk)
-#elif defined(__FreeBSD__)
-active_work(struct irq_work *wrk)
-#endif
 {
 	struct i915_active *ref = container_of(wrk, typeof(*ref), work);
 
@@ -184,11 +180,7 @@ active_retire(struct i915_active *ref)
 		return;
 
 	if (ref->flags & I915_ACTIVE_RETIRE_SLEEPS) {
-#ifdef __linux__
 		queue_work(system_unbound_wq, &ref->work);
-#elif defined(__FreeBSD__)
-		irq_work_queue(&ref->work);
-#endif
 		return;
 	}
 
@@ -307,11 +299,7 @@ void __i915_active_init(struct i915_active *ref,
 	atomic_set(&ref->count, 0);
 	__mutex_init(&ref->mutex, "i915_active", mkey);
 	__i915_active_fence_init(&ref->excl, NULL, excl_retire);
-#ifdef __linux__
 	INIT_WORK(&ref->work, active_work);
-#elif defined(__FreeBSD__)
-	init_irq_work(&ref->work, active_work);
-#endif
 #if IS_ENABLED(CONFIG_LOCKDEP)
 	lockdep_init_map(&ref->work.lockdep_map, "i915_active.work", wkey, 0);
 #endif
@@ -526,11 +514,7 @@ int i915_active_wait(struct i915_active *ref)
 	if (wait_var_event_interruptible(ref, i915_active_is_idle(ref)))
 		return -EINTR;
 
-#ifdef __linux__
 	flush_work(&ref->work);
-#elif defined(__FreeBSD__)
-	irq_work_sync(&ref->work);
-#endif
 	return 0;
 }
 
@@ -616,11 +600,7 @@ void i915_active_fini(struct i915_active *ref)
 {
 	debug_active_fini(ref);
 	GEM_BUG_ON(atomic_read(&ref->count));
-#ifdef __linux__
 	GEM_BUG_ON(work_pending(&ref->work));
-#elif defined(__FreeBSD__)
-	irq_work_sync(&ref->work);
-#endif
 	GEM_BUG_ON(!RB_EMPTY_ROOT(&ref->tree));
 	mutex_destroy(&ref->mutex);
 }

--- a/drivers/gpu/drm/i915/i915_active_types.h
+++ b/drivers/gpu/drm/i915/i915_active_types.h
@@ -14,9 +14,6 @@
 #include <linux/rbtree.h>
 #include <linux/rcupdate.h>
 #include <linux/workqueue.h>
-#ifdef __FreeBSD__
-#include <linux/irq_work.h>
-#endif
 
 #include "i915_utils.h"
 
@@ -49,13 +46,7 @@ struct i915_active {
 	int (*active)(struct i915_active *ref);
 	void (*retire)(struct i915_active *ref);
 
-#ifdef __linux__
 	struct work_struct work;
-#elif defined(__FreeBSD__)
-	/* On FreeBSD this work is sporadically scheduled
-	 * within a critical section. */
-	struct irq_work work;
-#endif
 
 	struct llist_head preallocated_barriers;
 };

--- a/drivers/gpu/drm/i915/i915_scheduler.c
+++ b/drivers/gpu/drm/i915/i915_scheduler.c
@@ -106,12 +106,6 @@ find_priolist:
 	if (prio == I915_PRIORITY_NORMAL) {
 		p = &execlists->default_priolist;
 	} else {
-#ifdef __FreeBSD__
-		/* FreeBSD cannot allocate memory from critical section */
-		if (unlikely(curthread->td_critnest != 0))
-			p = NULL;
-		else
-#endif
 		p = kmem_cache_alloc(global.slab_priorities, GFP_ATOMIC);
 		/* Convert an allocation failure to a priority bump */
 		if (unlikely(!p)) {

--- a/linuxkpi/gplv2/include/linux/dma-resv.h
+++ b/linuxkpi/gplv2/include/linux/dma-resv.h
@@ -47,6 +47,9 @@
 #ifdef __FreeBSD__
 /* On Linux linux/preempt.h is included through linux/seqlock.h */
 #include <linux/preempt.h>
+#include <sys/param.h>
+#include <sys/lock.h>
+#include <sys/rwlock.h>
 #endif
 
 extern struct ww_class reservation_ww_class;
@@ -76,6 +79,9 @@ struct dma_resv_list {
 struct dma_resv {
 	struct ww_mutex lock;
 	seqcount_t seq;
+#ifdef __FreeBSD__
+	struct rwlock rw;
+#endif
 
 	struct dma_fence __rcu *fence_excl;
 	struct dma_resv_list __rcu *fence;


### PR DESCRIPTION
as some callbacks called through dma_fence_is_signaled use various
blockable calls triggering kernel assertions. Instead of it use rwlock
to block seqlock readers if dma_resv_add_shared_fence is preempted.

Revert some hacks drm-kmod uses to workaround the assertions.