### PR TITLE
i915: Fix build with !DEBUGFS case.

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_gt.c
+++ b/drivers/gpu/drm/i915/gt/intel_gt.c
@@ -320,7 +320,9 @@ void intel_gt_driver_register(struct intel_gt *gt)
 {
 	intel_rps_driver_register(&gt->rps);
 
+#if defined(CONFIG_DEBUG_FS)
 	debugfs_gt_register(gt);
+#endif
 }
 
 static int intel_gt_init_scratch(struct intel_gt *gt, unsigned int size)

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -113,10 +113,7 @@ SRCS+=	dvo_ch7017.c \
 	vlv_dsi_pll.c
 
 # gt/*
-SRCS+=	debugfs_engines.c \
-	debugfs_gt.c \
-	debugfs_gt_pm.c \
-	gen6_ppgtt.c \
+SRCS+=	gen6_ppgtt.c \
 	gen6_renderstate.c \
 	gen7_renderclear.c \
 	gen7_renderstate.c \
@@ -215,6 +212,9 @@ SRCS+=	i915_ioc32.c
 SRCS+==	i915_debugfs.c \
 	i915_gemfs.c \
 	intel_pipe_crc.c
+SRCS+=	debugfs_engines.c \
+	debugfs_gt.c \
+	debugfs_gt_pm.c
 .endif
 
 .if !empty(KCONFIG:MDRM_FBDEV_EMULATION)


### PR DESCRIPTION
For !DEBUGFS case, the module would fail to load with:

```
link_elf_obj: symbol debugfs_create_dir undefined
linker_load_file: /boot/kernel/i915kms.ko - unsupported file type
```

This change removes the debugfs dependencies from `i915/gt/*`.