### PR TITLE
[master] do not panic on dma_buf_poll

### DIFF
--- a/drivers/dma-buf/dma-buf.c
+++ b/drivers/dma-buf/dma-buf.c
@@ -197,8 +197,8 @@ static int
 dma_buf_poll(struct file *fp, int events,
 	     struct ucred *active_cred, struct thread *td)
 {
-	panic("XXX implement me!!!");
-	return (0);
+	// TODO: implement this when we need it (mostly used for cross-device fence sync)
+	return (ENOTSUP);
 }
 
 


### PR DESCRIPTION
Some programs ([waypipe](https://gitlab.freedesktop.org/mstoeckl/waypipe/-/blob/15aab5c344636336f5327d91d3e6a92733503312/src/util.c#L205-214)) use poll to check inherited file descriptors, and some other programs (terminal emulators?) can have non-CLOEXEC dmabufs that leak into waypipe, causing a panic.

Pointy hat: ngor