### PR TITLE
drivers/gpu/drm/drm_os_freebsd.c: Remove iicbus_devclass

### DIFF
--- a/drivers/gpu/drm/drm_os_freebsd.c
+++ b/drivers/gpu/drm/drm_os_freebsd.c
@@ -200,9 +200,8 @@ MODULE_VERSION(drmn, 2);
 MODULE_DEPEND(drmn, agp, 1, 1, 1);
 #endif
 #if __FreeBSD_version >= 1400051
-DRIVER_MODULE(iicbus, drmn, iicbus_driver, iicbus_devclass, NULL, NULL);
-DRIVER_MODULE(acpi_iicbus, drmn, acpi_iicbus_driver, iicbus_devclass, NULL,
-    NULL);
+DRIVER_MODULE(iicbus, drmn, iicbus_driver, NULL, NULL);
+DRIVER_MODULE(acpi_iicbus, drmn, acpi_iicbus_driver, NULL, NULL);
 MODULE_DEPEND(drmn, iicbus, IICBUS_MINVER, IICBUS_PREFVER, IICBUS_MAXVER);
 MODULE_DEPEND(drmn, iic, 1, 1, 1);
 MODULE_DEPEND(drmn, iicbb, IICBB_MINVER, IICBB_PREFVER, IICBB_MAXVER);


### PR DESCRIPTION
It was removed from FreeBSD in freebsd/freebsd-src@676ea8e177. This patch fixes the build after this removal.

TODO: We lack a bump of `__FreeBSD_version` to support the old and the new code base I suppose.