### PR TITLE
LinuxKPI BSD: add include_next to pm.h

### DIFF
--- a/linuxkpi/bsd/include/linux/pm.h
+++ b/linuxkpi/bsd/include/linux/pm.h
@@ -3,6 +3,8 @@
 #ifndef _LINUX_PM_H
 #define _LINUX_PM_H
 
+#include_next <linux/pm.h>
+
 #include <linux/completion.h>
 #include <linux/wait.h>
 


### PR DESCRIPTION
add #include_next to pm.h to also have access to the in-tree file.
This will be necessary in main and stable/13 in order to migrate
pm_message_t from kernel.h to pm.h.

Sponsored by:	The FreeBSD Foundation