### PR TITLE
Cleanup some includes

### DIFF
--- a/linuxkpi/bsd/include/asm/processor.h
+++ b/linuxkpi/bsd/include/asm/processor.h
@@ -29,6 +29,7 @@
 #define _BSD_ASM_X86_PROCESSOR_H_
 
 #include <sys/types.h>
+#include <machine/cpufunc.h>
 #include <machine/cpu.h>
 
 struct cpuinfo_x86 {

--- a/linuxkpi/gplv2/src/linux_compat.c
+++ b/linuxkpi/gplv2/src/linux_compat.c
@@ -5,9 +5,6 @@
 #include <machine/specialreg.h>
 #include <machine/md_var.h>
 #endif
-#include <linux/bitops.h>
-#include <linux/idr.h>
-#include <linux/pci.h>
 
 #include <asm/processor.h>
 


### PR DESCRIPTION
One change add a missing include (not sure entirely why it is needed in this case but compiler complained, compiler wins ;-)

The other change removes superfluous includes discovered during https://github.com/freebsd/drm-kmod/pull/169