### PR TITLE
Fix powerpc64* and riscsv64* defines

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/os_types.h
+++ b/drivers/gpu/drm/amd/display/dc/os_types.h
@@ -60,6 +60,7 @@
 #define DC_FP_START() kernel_neon_begin()
 #define DC_FP_END() kernel_neon_end()
 #elif defined(CONFIG_PPC64)
+#ifdef __linux__
 #include <asm/switch_to.h>
 #include <asm/cputable.h>
 #define DC_FP_START() { \
@@ -86,6 +87,10 @@
 		preempt_enable(); \
 	} \
 }
+#elif defined(__FreeBSD__)
+#define DC_FP_START()
+#define DC_FP_END()
+#endif
 #endif
 #endif
 

--- a/kconfig.mk
+++ b/kconfig.mk
@@ -53,15 +53,18 @@ KCONFIG+=	DRM_AMD_DC_DCN \
 .endif
 .endif
 
-.if !empty(${MACHINE_ARCH:Mpowerpc64*})
+.if ${MACHINE_ARCH:Mpowerpc64*} != ""
 KCONFIG+=	64BIT \
 		PPC64
+		
+KCONFIG+=	DRM_AMD_DC_DCN \
+		DRM_AMD_DC_DCN3_0
 .endif
 
 .if ${MACHINE_CPUARCH} == "riscv"
 KCONFIG+=	RISCV
 
-.if !empty(${MACHINE_ARCH:Mriscv64*})
+.if ${MACHINE_ARCH:Mriscv64*} != ""
 KCONFIG+=	64BIT
 .endif
 .endif

--- a/kconfig.mk
+++ b/kconfig.mk
@@ -57,6 +57,7 @@ KCONFIG+=	DRM_AMD_DC_DCN \
 KCONFIG+=	64BIT \
 		PPC64
 		
+# DCN is only compile-tested.
 KCONFIG+=	DRM_AMD_DC_DCN \
 		DRM_AMD_DC_DCN3_0
 .endif


### PR DESCRIPTION
Related to https://github.com/freebsd/drm-kmod/issues/176.