### PR TITLE
linuxkpi: Fix build on i386

### DIFF
--- a/drivers/gpu/drm/i915/intel_uncore.h
+++ b/drivers/gpu/drm/i915/intel_uncore.h
@@ -32,7 +32,6 @@
 
 #ifdef __FreeBSD__
 #include <linux/kernel.h>	/* For container_of */
-#include <linux/io.h>		/* For writeb/readb */
 #endif
 
 #include "i915_reg.h"

--- a/linuxkpi/bsd/include/asm/processor.h
+++ b/linuxkpi/bsd/include/asm/processor.h
@@ -28,6 +28,9 @@
 #ifndef _BSD_ASM_X86_PROCESSOR_H_
 #define _BSD_ASM_X86_PROCESSOR_H_
 
+#if __FreeBSD_version < 1400067 && defined(__i386__)
+#include <sys/systm.h>
+#endif
 #if __FreeBSD_version < 1400066
 #include <sys/types.h>
 #include <machine/cpufunc.h>

--- a/linuxkpi/bsd/include/linux/io-64-nonatomic-lo-hi.h
+++ b/linuxkpi/bsd/include/linux/io-64-nonatomic-lo-hi.h
@@ -1,0 +1,47 @@
+#ifndef	_BSD_LKPI_LINUX_IO_64_NONATOMIC_LO_HI_H_
+#define	_BSD_LKPI_LINUX_IO_64_NONATOMIC_LO_HI_H_
+
+#include <sys/param.h>
+
+#if __FreeBSD_version >= 1400067
+#include_next <linux/io-64-nonatomic-lo-hi.h>
+#else
+
+#include <linux/io.h>
+
+static inline uint64_t
+lo_hi_readq(const volatile void *addr)
+{
+	const volatile uint32_t *p = addr;
+	uint32_t l, h;
+
+	__io_br();
+	l = le32toh(__raw_readl(p));
+	h = le32toh(__raw_readl(p + 1));
+	__io_ar();
+
+	return (l + ((uint64_t)h << 32));
+}
+
+static inline void
+lo_hi_writeq(uint64_t v, volatile void *addr)
+{
+	volatile uint32_t *p = addr;
+
+	__io_bw();
+	__raw_writel(htole32(v), p);
+	__raw_writel(htole32(v >> 32), p + 1);
+	__io_aw();
+}
+
+#ifndef readq
+#define readq(addr)	lo_hi_readq(addr)
+#endif
+
+#ifndef writeq
+#define writeq(v, addr)	lo_hi_writeq(v, addr)
+#endif
+
+#endif /* __FreeBSD_version >= 1400067 */
+
+#endif	/* _BSD_LKPI_LINUX_IO_64_NONATOMIC_LO_HI_H_ */


### PR DESCRIPTION
Add missing sys/systm.h include and non-atomic versions of readq() and writeq() for __FreeBSD_version < 1400067.