### PR TITLE
linuxkpi: Fix commit "Chase base linuxkpi MFC"'s 13-STABLE version

### DIFF
--- a/linuxkpi/bsd/include/linux/dma-mapping.h
+++ b/linuxkpi/bsd/include/linux/dma-mapping.h
@@ -15,7 +15,7 @@
 #define dma_unmap_resource(dev, dma_addr, size, dir, attrs)     \
 	linux_dma_unmap(dev, dma_addr, size)
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 static inline int
 dma_map_sgtable(struct device *dev, struct sg_table *sgt,
     enum dma_data_direction dir,

--- a/linuxkpi/bsd/include/linux/io.h
+++ b/linuxkpi/bsd/include/linux/io.h
@@ -5,7 +5,7 @@
 
 #include_next <linux/io.h>
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
  
 #if defined(__amd64__) || defined(__i386__) || defined(__aarch64__) || defined(__powerpc__) || defined(__riscv)
 static inline int

--- a/linuxkpi/bsd/include/linux/kernel.h
+++ b/linuxkpi/bsd/include/linux/kernel.h
@@ -6,7 +6,7 @@
 /* XXX */
 #define	irqs_disabled() (curthread->td_critnest != 0 || curthread->td_intr_nesting_level != 0)
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 #define add_taint(a,b)
 
 #include <linux/irqflags.h>

--- a/linuxkpi/bsd/include/linux/mm.h
+++ b/linuxkpi/bsd/include/linux/mm.h
@@ -3,7 +3,7 @@
 
 #include_next <linux/mm.h>
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 static inline int
 trylock_page(struct page *page)
 {

--- a/linuxkpi/bsd/include/linux/pm.h
+++ b/linuxkpi/bsd/include/linux/pm.h
@@ -7,7 +7,7 @@
 
 #include <linux/completion.h>
 #include <linux/wait.h>
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 
 #define	PM_EVENT_FREEZE		0x0001
 #define	PM_EVENT_SUSPEND	0x0002

--- a/linuxkpi/bsd/include/linux/refcount.h
+++ b/linuxkpi/bsd/include/linux/refcount.h
@@ -3,7 +3,7 @@
 
 #include_next <linux/refcount.h>
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 /*
  * We can't change this right now as struct kref from linuxkpi base doesn't
  * use refcount_t but an atomic_t directly

--- a/linuxkpi/gplv2/include/linux/compiler.h
+++ b/linuxkpi/gplv2/include/linux/compiler.h
@@ -46,7 +46,7 @@
 
 // XXX: Move to better place?
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 static inline void *
 memset32(uint32_t *s, uint32_t v, size_t count)
 {
@@ -80,11 +80,11 @@ memset_p(void **p, void *v, size_t n)
 #include <sys/types.h>
 #include <linux/math64.h>
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 #define	atomic_fetch_inc(v)	(atomic_inc_return(v) - 1)
 #endif
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 struct linux_kmem_cache;
 static inline int
 kmem_cache_shrink(struct linux_kmem_cache *c)
@@ -96,7 +96,7 @@ kmem_cache_shrink(struct linux_kmem_cache *c)
 
 
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 
 static inline uint64_t mul_u64_u32_div(uint64_t a, uint32_t mul, uint32_t divisor)
 {
@@ -131,7 +131,7 @@ static inline uint64_t mul_u64_u32_shr(uint64_t a, uint32_t mul, unsigned int sh
 }
 #endif
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 /* Copied from Linux */
 static inline unsigned long array_index_mask_nospec(unsigned long index,
 						    unsigned long size)

--- a/linuxkpi/gplv2/include/linux/pagevec.h
+++ b/linuxkpi/gplv2/include/linux/pagevec.h
@@ -69,7 +69,7 @@ check_move_unevictable_pages(struct pagevec *pvec)
 	UNIMPLEMENTED();
 }
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 static inline void
 mapping_clear_unevictable(vm_object_t mapping)
 {

--- a/linuxkpi/gplv2/include/linux/pci.h
+++ b/linuxkpi/gplv2/include/linux/pci.h
@@ -35,7 +35,7 @@ resource_contains(struct linux_resource *a, struct linux_resource *b)
 	return a->start <= b->start && a->end >= b->end;
 }
 
-#if __FreeBSD_version < 1301506
+#if __FreeBSD_version < 1301507
 
 static inline bool
 pci_is_thunderbolt_attached(struct pci_dev *pdev)


### PR DESCRIPTION
This fixes drm-kmod's build on FreeBSD 13-STABLE before the recent merges in base and the corresponding version bump to 1301507.