### PR TITLE
drm_sysctl_freebsd.c: Adapt loop over `SYSCTL_CHILDREN()` to FreeBSD 1400071+

### DIFF
--- a/drivers/gpu/drm/drm_sysctl_freebsd.c
+++ b/drivers/gpu/drm/drm_sysctl_freebsd.c
@@ -90,7 +90,12 @@ drm_sysctl_init(struct drm_device *dev)
 
 	/* Find the next free slot under hw.dri */
 	i = 0;
-	SLIST_FOREACH(oid, SYSCTL_CHILDREN(drioid), oid_link) {
+#ifdef SYSCTL_FOREACH
+	SYSCTL_FOREACH(oid, SYSCTL_CHILDREN(drioid))
+#else
+	SLIST_FOREACH(oid, SYSCTL_CHILDREN(drioid), oid_link)
+#endif
+	{
 		if (i == oid->oid_name[0] - '0' && oid->oid_name[1] == 0)
 			i++;
 	}


### PR DESCRIPTION
In commit freebsd/freebsd-src@d3f96f661050e9bd21fe29931992a8b9e67ff189, the structure was changed from a linked list to a red-black tree.

`__FreeBSD_version` was bumped to 1400071 in the process.