### PR TITLE
linuxkpi: Fix return value of dma_map_sgtable

### DIFF
--- a/linuxkpi/bsd/include/linux/dma-mapping.h
+++ b/linuxkpi/bsd/include/linux/dma-mapping.h
@@ -22,7 +22,14 @@ dma_map_sgtable(struct device *dev, struct sg_table *sgt,
     unsigned long attrs)
 {
 
-	return (dma_map_sg_attrs(dev, sgt->sgl, sgt->nents, dir, attrs));
+	int nents = dma_map_sg_attrs(dev, sgt->sgl, sgt->nents, dir, attrs);
+
+	if (nents < 0) {
+		return nents;
+	} else {
+		sgt->nents = nents;
+		return 0;
+	}
 }
 
 static inline void


### PR DESCRIPTION
dma_map_sgtable internally uses the dma_map_sg_attrs helper. The problem is that dma_map_sg_attrs returns the number of entries mapped, whereas dma_map_sgtable returns nonzero on failure.  This leads to dma_map_sgtable returning non-zero-but-positive values which tricks other areas of the stack into thinking nents is a valid pointer.

This checks if nents is valid and returns zero if so, updating the nents field in sgt. This fixes PRIME render offload with nvidia-drm.

This review handles installs before FreeBSD version 1400066, where dma_map_sgtable comes from drm-kmod instead of from base.

Related: https://reviews.freebsd.org/D37611