### PR TITLE
scripts/drmpatch: Ring the terminal bell when the script exits

### DIFF
--- a/scripts/drmpatch
+++ b/scripts/drmpatch
@@ -9,6 +9,8 @@ EOF
 	exit 1
 }
 
+trap 'printf "\a\n"' EXIT
+
 if [ $# -ne 1 ]; then
 	usage
 fi


### PR DESCRIPTION
It is useful when the script runs in an unattended terminal window. If the terminal and the window manager/desktop environment are configured for it, the bell will trigger the "urgent hint" for the terminal window. For instance with Sway and Waybar, the workspace number/name in bar will be red, likewise for the terminal window title and borders.

This way, we can run the script, forget about it and do something else. When the script exits, for instance because it failed to apply a patch, we are notified.