### PR TITLE
i915: Remove `totalram_pages()` function

### DIFF
--- a/drivers/gpu/drm/i915/gem/i915_gem_shmem.c
+++ b/drivers/gpu/drm/i915/gem/i915_gem_shmem.c
@@ -14,7 +14,7 @@
 #include "i915_scatterlist.h"
 #include "i915_trace.h"
 
-#ifdef __FreeBSD__
+#if !defined(__FreeBSD_version) || __FreeBSD_version < 1400080
 static inline unsigned long totalram_pages(void) { return physmem; }
 #endif
 


### PR DESCRIPTION
This function will be exposed by linuxkpi shortly.

See https://reviews.freebsd.org/D38531.