### PR TITLE
dma-buf: Call rcu_read_unlock() before locking `cursor->obj->rw`

### DIFF
--- a/drivers/dma-buf/dma-resv.c
+++ b/drivers/dma-buf/dma-resv.c
@@ -369,8 +369,10 @@ static void dma_resv_iter_restart_unlocked(struct dma_resv_iter *cursor)
 	 * for write may be blocked. In that case reader thread should
 	 * be blocked too.
 	 */
+	rcu_read_unlock();
 	rw_rlock(&cursor->obj->rw);
 	rw_runlock(&cursor->obj->rw);
+	rcu_read_lock();
 #endif
 }
 


### PR DESCRIPTION
The function is called in between `rcu_read_lock()`/`rcu_read_unlock()`. Dropping this lock to wait for the writer thread to finish on FreeBSD was lost in the code refactoring.