### PR TITLE
Remove locking around compute_mst_dsc_configs_for_link

### DIFF
--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_mst_types.c
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_mst_types.c
@@ -982,13 +982,10 @@ bool compute_mst_dsc_configs_for_state(struct drm_atomic_state *state,
 		if (!is_dsc_need_re_compute(state, dc_state, stream->link))
 			continue;
 
-		mutex_lock(&aconnector->mst_mgr.lock);
 		if (!compute_mst_dsc_configs_for_link(state, dc_state, stream->link,
 			vars, &link_vars_start_index)) {
-			mutex_unlock(&aconnector->mst_mgr.lock);
 			return false;
 		}
-		mutex_unlock(&aconnector->mst_mgr.lock);
 
 		for (j = 0; j < dc_state->stream_count; j++) {
 			if (dc_state->streams[j]->link == stream->link)


### PR DESCRIPTION
This fixes external monitor support for amdgpu

Obtained from:	https://github.com/torvalds/linux/commit/14b651b22224251b35618259da714adb0b5f10ee
Reported:	https://github.com/freebsd/drm-kmod/issues/188