### PR TITLE
Use `drm_fb_helper`'s emulation of Linux `fbdev` to integrate with FreeBSD's vt(4)

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_fb.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_fb.c
@@ -46,7 +46,6 @@
    the helper contains a pointer to amdgpu framebuffer baseclass.
 */
 
-#ifdef __linux__
 static int
 amdgpufb_open(struct fb_info *info, int user)
 {
@@ -69,18 +68,15 @@ amdgpufb_release(struct fb_info *info, int user)
 	pm_runtime_put_autosuspend(fb_helper->dev->dev);
 	return 0;
 }
-#endif	/* __linux__ */
 
 static const struct fb_ops amdgpufb_ops = {
 	.owner = THIS_MODULE,
 	DRM_FB_HELPER_DEFAULT_OPS,
-#ifdef __linux__
 	.fb_open = amdgpufb_open,
 	.fb_release = amdgpufb_release,
 	.fb_fillrect = drm_fb_helper_cfb_fillrect,
 	.fb_copyarea = drm_fb_helper_cfb_copyarea,
 	.fb_imageblit = drm_fb_helper_cfb_imageblit,
-#endif
 };
 
 

--- a/drivers/gpu/drm/drm_fb_helper.c
+++ b/drivers/gpu/drm/drm_fb_helper.c
@@ -1741,13 +1741,6 @@ static void drm_fb_helper_fill_var(struct fb_info *info,
 
 	info->var.xres = fb_width;
 	info->var.yres = fb_height;
-
-#ifdef __FreeBSD__ // fbio is BSD stuff
-	info->fbio.fb_name = device_get_nameunit(fb_helper->dev->dev->bsddev);
-	info->fbio.fb_width = fb->width;
-	info->fbio.fb_height = fb->height;
-	info->fbio.fb_depth = info->var.bits_per_pixel;
-#endif
 }
 
 /**
@@ -1891,9 +1884,6 @@ __drm_fb_helper_initial_config_and_unlock(struct drm_fb_helper *fb_helper,
 		info->flags |= FBINFO_HIDE_SMEM_START;
 
 #ifdef __FreeBSD__
-	info->fbio.fb_video_dev = device_get_parent(fb_helper->dev->dev->bsddev);
-	info->fbio.fb_bpp = bpp_sel;
-	info->fb_bsddev = fb_helper->dev->dev->bsddev;
 	struct vt_kms_softc *sc = (struct vt_kms_softc *)info->fbio.fb_priv;
 	if (sc)
 		sc->fb_helper = fb_helper;

--- a/drivers/gpu/drm/drm_fb_helper.c
+++ b/drivers/gpu/drm/drm_fb_helper.c
@@ -169,7 +169,11 @@ int drm_fb_helper_debug_enter(struct fb_info *info)
 				continue;
 
 			funcs =	mode_set->crtc->helper_private;
+#ifdef __linux__
 			if (funcs->mode_set_base_atomic == NULL)
+#elif defined(__FreeBSD__)
+			if (funcs == NULL || funcs->mode_set_base_atomic == NULL)
+#endif
 				continue;
 
 			if (drm_drv_uses_atomic_modeset(mode_set->crtc->dev))

--- a/drivers/gpu/drm/drm_modeset_lock.c
+++ b/drivers/gpu/drm/drm_modeset_lock.c
@@ -138,11 +138,6 @@ void drm_modeset_lock_all(struct drm_device *dev)
 	struct drm_modeset_acquire_ctx *ctx;
 	int ret;
 
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return;
-#endif
-
 	ctx = kzalloc(sizeof(*ctx), GFP_KERNEL | __GFP_NOFAIL);
 	if (WARN_ON(!ctx))
 		return;
@@ -196,11 +191,6 @@ void drm_modeset_unlock_all(struct drm_device *dev)
 	struct drm_mode_config *config = &dev->mode_config;
 	struct drm_modeset_acquire_ctx *ctx = config->acquire_ctx;
 
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return;
-#endif
-
 	if (WARN_ON(!ctx))
 		return;
 
@@ -225,10 +215,8 @@ void drm_warn_on_modeset_not_all_locked(struct drm_device *dev)
 	struct drm_crtc *crtc;
 
 	/* Locking is currently fubar in the panic handler. */
-#ifdef __FreeBSD__
 	if (oops_in_progress)
 		return;
-#endif
 
 	drm_for_each_crtc(crtc, dev)
 		WARN_ON(!drm_modeset_is_locked(&crtc->mutex));
@@ -250,11 +238,6 @@ EXPORT_SYMBOL(drm_warn_on_modeset_not_all_locked);
 void drm_modeset_acquire_init(struct drm_modeset_acquire_ctx *ctx,
 		uint32_t flags)
 {
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return;
-#endif
-
 	memset(ctx, 0, sizeof(*ctx));
 	ww_acquire_init(&ctx->ww_ctx, &crtc_ww_class);
 	INIT_LIST_HEAD(&ctx->locked);
@@ -270,11 +253,6 @@ EXPORT_SYMBOL(drm_modeset_acquire_init);
  */
 void drm_modeset_acquire_fini(struct drm_modeset_acquire_ctx *ctx)
 {
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return;
-#endif
-
 	ww_acquire_fini(&ctx->ww_ctx);
 }
 EXPORT_SYMBOL(drm_modeset_acquire_fini);
@@ -287,11 +265,6 @@ EXPORT_SYMBOL(drm_modeset_acquire_fini);
  */
 void drm_modeset_drop_locks(struct drm_modeset_acquire_ctx *ctx)
 {
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return;
-#endif
-
 	if (WARN_ON(ctx->contended))
 		__drm_stack_depot_print(ctx->stack_depot);
 
@@ -311,11 +284,6 @@ static inline int modeset_lock(struct drm_modeset_lock *lock,
 		bool interruptible, bool slow)
 {
 	int ret;
-
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return 0;
-#endif
 
 	if (WARN_ON(ctx->contended))
 		__drm_stack_depot_print(ctx->stack_depot);
@@ -371,11 +339,6 @@ int drm_modeset_backoff(struct drm_modeset_acquire_ctx *ctx)
 {
 	struct drm_modeset_lock *contended = ctx->contended;
 
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return 0;
-#endif
-
 	ctx->contended = NULL;
 	ctx->stack_depot = 0;
 
@@ -420,11 +383,6 @@ EXPORT_SYMBOL(drm_modeset_lock_init);
 int drm_modeset_lock(struct drm_modeset_lock *lock,
 		struct drm_modeset_acquire_ctx *ctx)
 {
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return 0;
-#endif
-
 	if (ctx)
 		return modeset_lock(lock, ctx, ctx->interruptible, false);
 
@@ -444,10 +402,6 @@ EXPORT_SYMBOL(drm_modeset_lock);
  */
 int drm_modeset_lock_single_interruptible(struct drm_modeset_lock *lock)
 {
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return 0;
-#endif
 	return ww_mutex_lock_interruptible(&lock->mutex, NULL);
 }
 EXPORT_SYMBOL(drm_modeset_lock_single_interruptible);
@@ -458,11 +412,6 @@ EXPORT_SYMBOL(drm_modeset_lock_single_interruptible);
  */
 void drm_modeset_unlock(struct drm_modeset_lock *lock)
 {
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return;
-#endif
-
 	list_del_init(&lock->head);
 	ww_mutex_unlock(&lock->mutex);
 }
@@ -495,11 +444,6 @@ int drm_modeset_lock_all_ctx(struct drm_device *dev,
 	struct drm_crtc *crtc;
 	struct drm_plane *plane;
 	int ret;
-
-#ifdef __FreeBSD__
-	if (oops_in_progress)
-		return 0;
-#endif
 
 	ret = drm_modeset_lock(&dev->mode_config.connection_mutex, ctx);
 	if (ret)

--- a/drivers/gpu/drm/drm_os_freebsd.h
+++ b/drivers/gpu/drm/drm_os_freebsd.h
@@ -40,6 +40,12 @@ struct drm_minor;
 int drm_dev_alias(struct device *dev, struct drm_minor *minor, const char *minor_str);
 void cancel_reset_debug_log(void);
 
+void vt_freeze_main_vd(struct apertures_struct *a);
+void vt_unfreeze_main_vd(void);
+
+int register_fictitious_range(vm_paddr_t start, vm_paddr_t end);
+void unregister_fictitious_range(vm_paddr_t start, vm_paddr_t end);
+
 void vt_restore_fbdev_mode(void *arg, int pending);
 int vt_kms_postswitch(void *arg);
 

--- a/drivers/gpu/drm/drm_os_freebsd.h
+++ b/drivers/gpu/drm/drm_os_freebsd.h
@@ -20,11 +20,6 @@ __FBSDID("$FreeBSD$");
 #define DRM_DEV_UID	UID_ROOT
 #define DRM_DEV_GID	GID_VIDEO
 
-struct vt_kms_softc {
-	struct drm_fb_helper    *fb_helper;
-	struct task              fb_mode_task;
-};
-
 /* XXXKIB what is the right code for the FreeBSD ? */
 /* kib@ used ENXIO here -- dumbbell@ */
 #define	EREMOTEIO	EIO
@@ -35,6 +30,7 @@ struct vt_kms_softc {
 MALLOC_DECLARE(DRM_MEM_DRIVER);
 
 extern devclass_t drm_devclass;
+extern int skip_ddb;
 
 struct drm_minor;
 int drm_dev_alias(struct device *dev, struct drm_minor *minor, const char *minor_str);
@@ -45,9 +41,6 @@ void vt_unfreeze_main_vd(void);
 
 int register_fictitious_range(vm_paddr_t start, vm_paddr_t end);
 void unregister_fictitious_range(vm_paddr_t start, vm_paddr_t end);
-
-void vt_restore_fbdev_mode(void *arg, int pending);
-int vt_kms_postswitch(void *arg);
 
 #if 0
 struct linux_fb_info;

--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -74,7 +74,6 @@ static int intel_fbdev_set_par(struct fb_info *info)
 	return ret;
 }
 
-#ifdef __linux__
 static int intel_fbdev_blank(int blank, struct fb_info *info)
 {
 	struct drm_fb_helper *fb_helper = info->par;
@@ -103,19 +102,16 @@ static int intel_fbdev_pan_display(struct fb_var_screeninfo *var,
 
 	return ret;
 }
-#endif
 
 static const struct fb_ops intelfb_ops = {
 	.owner = THIS_MODULE,
 	DRM_FB_HELPER_DEFAULT_OPS,
 	.fb_set_par = intel_fbdev_set_par,
-#ifdef __linux__
 	.fb_fillrect = drm_fb_helper_cfb_fillrect,
 	.fb_copyarea = drm_fb_helper_cfb_copyarea,
 	.fb_imageblit = drm_fb_helper_cfb_imageblit,
 	.fb_pan_display = intel_fbdev_pan_display,
 	.fb_blank = intel_fbdev_blank,
-#endif
 };
 
 static int intelfb_alloc(struct drm_fb_helper *helper,

--- a/drivers/gpu/drm/i915/gem/i915_gem_stolen.c
+++ b/drivers/gpu/drm/i915/gem/i915_gem_stolen.c
@@ -410,12 +410,6 @@ static int i915_gem_init_stolen(struct intel_memory_region *mem)
 		return 0;
 	}
 
-#ifdef __FreeBSD__
-	DRM_INFO("Got stolen memory base 0x%x, size 0x%x\n",
-	    intel_graphics_stolen_res.start,
-	    resource_size(&intel_graphics_stolen_res));
-#endif
-
 	if (resource_size(&mem->region) == 0)
 		return 0;
 

--- a/drivers/gpu/drm/i915/i915_module.c
+++ b/drivers/gpu/drm/i915/i915_module.c
@@ -80,6 +80,17 @@ static int __init i915_init(void)
 {
 	int err, i;
 
+#ifdef __FreeBSD__
+#if defined(__amd64__)
+	intel_graphics_stolen_res = (struct linux_resource)
+		DEFINE_RES_MEM(intel_graphics_stolen_base,
+		    intel_graphics_stolen_size);
+	DRM_INFO("Got Intel graphics stolen memory base 0x%x, size 0x%x\n",
+	    intel_graphics_stolen_res.start,
+	    resource_size(&intel_graphics_stolen_res));
+#endif
+#endif
+
 	for (i = 0; i < ARRAY_SIZE(init_funcs); i++) {
 		err = init_funcs[i].init();
 		if (err < 0) {

--- a/drivers/gpu/drm/i915/i915_pci.c
+++ b/drivers/gpu/drm/i915/i915_pci.c
@@ -1256,6 +1256,5 @@ void i915_pci_unregister_driver(void)
 	pci_unregister_driver(&i915_pci_driver);
 #elif defined(__FreeBSD__)
 	linux_pci_unregister_drm_driver(&i915_pci_driver);
-	vt_unfreeze_main_vd();
 #endif
 }

--- a/drivers/gpu/drm/i915/intel_freebsd.c
+++ b/drivers/gpu/drm/i915/intel_freebsd.c
@@ -158,15 +158,3 @@ linux_intel_gtt_insert_sg_entries(struct sg_table *st, unsigned int pg_start,
 
 	intel_gtt_read_pte(pg_start + i - 1);
 }
-
-#if defined(__amd64__)
-static void
-intel_freebsd_init(void *arg __unused)
-{
-	/* Defined in $SYSDIR/x86/pci/pci_early_quirks.c */
-	intel_graphics_stolen_res = (struct linux_resource)
-		DEFINE_RES_MEM(intel_graphics_stolen_base,
-		    intel_graphics_stolen_size);
-}
-SYSINIT(intel_freebsd, SI_SUB_DRIVERS, SI_ORDER_ANY, intel_freebsd_init, NULL);
-#endif

--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -41,6 +41,7 @@ __FBSDID("$FreeBSD$");
 #include <dev/vt/vt.h>
 #include <dev/vt/hw/fb/vt_fb.h>
 
+#include <drm/drm_fb_helper.h>
 #include <linux/fb.h>
 #undef fb_info
 #include <drm/drm_os_freebsd.h>
@@ -191,10 +192,18 @@ static int
 __register_framebuffer(struct linux_fb_info *fb_info)
 {
 	int i, err;
+	struct drm_fb_helper *fb_helper;
+
+	fb_helper =
+	    ((struct vt_kms_softc *)fb_info->fbio.fb_priv)->fb_helper;
+	fb_info->fb_bsddev = fb_helper->dev->dev->bsddev;
+	fb_info->fbio.fb_video_dev = device_get_parent(fb_info->fb_bsddev);
+	fb_info->fbio.fb_name = device_get_nameunit(fb_info->fb_bsddev);
 
 	fb_info->fbio.fb_type = FBTYPE_PCIMISC;
 	fb_info->fbio.fb_height = fb_info->var.yres;
 	fb_info->fbio.fb_width = fb_info->var.xres;
+	fb_info->fbio.fb_bpp = fb_info->var.bits_per_pixel;
 	fb_info->fbio.fb_depth = fb_info->var.bits_per_pixel;
 	fb_info->fbio.fb_cmsize = 0;
 	fb_info->fbio.fb_stride = fb_info->fix.line_length;

--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -302,3 +302,47 @@ linux_fb_get_options(const char *connector_name, char **option)
 
 	return (*option != NULL ? 0 : -ENOENT);
 }
+
+void
+cfb_fillrect(struct linux_fb_info *info, const struct fb_fillrect *rect)
+{
+}
+
+void
+cfb_copyarea(struct linux_fb_info *info, const struct fb_copyarea *area)
+{
+}
+
+void
+cfb_imageblit(struct linux_fb_info *info, const struct fb_image *image)
+{
+}
+
+void
+sys_fillrect(struct linux_fb_info *info, const struct fb_fillrect *rect)
+{
+}
+
+void
+sys_copyarea(struct linux_fb_info *info, const struct fb_copyarea *area)
+{
+}
+
+void
+sys_imageblit(struct linux_fb_info *info, const struct fb_image *image)
+{
+}
+
+ssize_t
+fb_sys_read(struct linux_fb_info *info, char __user *buf,
+    size_t count, loff_t *ppos)
+{
+	return (0);
+}
+
+ssize_t
+fb_sys_write(struct linux_fb_info *info, const char __user *buf,
+    size_t count, loff_t *ppos)
+{
+	return (0);
+}

--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -229,6 +229,7 @@ __register_framebuffer(struct linux_fb_info *fb_info)
 			    "not attached to vt(4) console; "
 			    "another device has precedence (err=%d)\n",
 			    err);
+			err = 0;
 			break;
 		default:
 			device_printf(fb_info->fbio.fb_fbd_dev,

--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -108,15 +108,16 @@ vt_restore_fbdev_mode(void *arg, int pending)
 }
 
 void
-fb_info_print(struct fb_info *t)
+fb_info_print(struct linux_fb_info *info)
 {
 	printf("start FB_INFO:\n");
-	printf("type=%d height=%d width=%d depth=%d\n",
-	       t->fb_type, t->fb_height, t->fb_width, t->fb_depth);
+	printf("height=%d width=%d depth=%d\n",
+	       info->var.yres, info->var.xres, info->var.bits_per_pixel);
 	printf("pbase=0x%lx vbase=0x%lx\n",
-	       t->fb_pbase, t->fb_vbase);
-	printf("name=%s flags=0x%x stride=%d bpp=%d\n",
-	       t->fb_name, t->fb_flags, t->fb_stride, t->fb_bpp);
+	       info->fix.smem_start, info->screen_base);
+	printf("name=%s id=%s flags=0x%x stride=%d\n",
+	       info->fbio.fb_name, info->fix.id, info->fbio.fb_flags,
+	       info->fix.line_length);
 	printf("end FB_INFO\n");
 }
 
@@ -238,7 +239,7 @@ __register_framebuffer(struct linux_fb_info *fb_info)
 		}
 		return (-err);
 	}
-	fb_info_print(&fb_info->fbio);
+	fb_info_print(fb_info);
 	return 0;
 }
 

--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -258,16 +258,18 @@ __unregister_framebuffer(struct linux_fb_info *fb_info)
 {
 	int ret = 0;
 
+	vt_drmfb_detach(&fb_info->fbio);
+
 	if (fb_info->fbio.fb_fbd_dev) {
 		mtx_lock(&Giant);
 		device_delete_child(fb_info->fb_bsddev, fb_info->fbio.fb_fbd_dev);
 		mtx_unlock(&Giant);
 		fb_info->fbio.fb_fbd_dev = NULL;
 	}
-	vt_drmfb_detach(&fb_info->fbio);
 
 	if (fb_info->fbops->fb_destroy)
 		fb_info->fbops->fb_destroy(fb_info);
+
 	return 0;
 }
 

--- a/drivers/gpu/drm/radeon/radeon_fb.c
+++ b/drivers/gpu/drm/radeon/radeon_fb.c
@@ -48,7 +48,6 @@ struct radeon_fbdev {
 	struct radeon_device *rdev;
 };
 
-#ifdef __linux__
 static int
 radeonfb_open(struct fb_info *info, int user)
 {
@@ -74,18 +73,15 @@ radeonfb_release(struct fb_info *info, int user)
 	pm_runtime_put_autosuspend(rdev->ddev->dev);
 	return 0;
 }
-#endif	/* __linux__ */
 
 static const struct fb_ops radeonfb_ops = {
 	.owner = THIS_MODULE,
 	DRM_FB_HELPER_DEFAULT_OPS,
-#ifdef __linux__
 	.fb_open = radeonfb_open,
 	.fb_release = radeonfb_release,
 	.fb_fillrect = drm_fb_helper_cfb_fillrect,
 	.fb_copyarea = drm_fb_helper_cfb_copyarea,
 	.fb_imageblit = drm_fb_helper_cfb_imageblit,
-#endif
 };
 
 

--- a/drivers/gpu/drm/vt_drmfb.c
+++ b/drivers/gpu/drm/vt_drmfb.c
@@ -1,0 +1,373 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2013 The FreeBSD Foundation
+ * Copyright (c) 2023 Jean-Sébastien Pédron <dumbbell@FreeBSD.org>
+ *
+ * This initial software `sys/dev/vt/hw/vt_fb.c` was developed by Aleksandr
+ * Rybalko under sponsorship from the FreeBSD Foundation.
+ * This file is a copy of the initial file and is modified by Jean-Sébastien
+ * Pédron.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/reboot.h>
+#include <sys/fbio.h>
+#include <dev/vt/vt.h>
+#include <dev/vt/hw/fb/vt_fb.h>
+#include <dev/vt/colors/vt_termcolors.h>
+
+#include <linux/fb.h>
+
+#include <drm/drm_fb_helper.h>
+
+/*
+ * `drm_fb_helper.h` redefines `fb_info` to be `linux_fb_info` to manage the
+ * name conflict between the Linux and FreeBSD structures, while avoiding a
+ * extensive rewrite and use of macros in the original drm_fb_helper.[ch]
+ * files.
+ *
+ * We need to undo this here because we use both structures.
+ */
+#undef	fb_info
+
+#include <drm/drm_os_freebsd.h>
+
+#include "vt_drmfb.h"
+
+#define	to_drm_fb_helper(fbio) ((struct drm_fb_helper *)fbio->fb_priv)
+#define	to_linux_fb_info(fbio) (to_drm_fb_helper(fbio)->fbdev)
+
+vd_init_t		vt_drmfb_init;
+vd_fini_t		vt_drmfb_fini;
+vd_blank_t		vt_drmfb_blank;
+vd_bitblt_bmp_t		vt_drmfb_bitblt_bitmap;
+vd_drawrect_t		vt_drmfb_drawrect;
+vd_setpixel_t		vt_drmfb_setpixel;
+vd_invalidate_text_t	vt_drmfb_invalidate_text;
+vd_postswitch_t		vt_drmfb_postswitch;
+
+static struct vt_driver vt_drmfb_driver = {
+	.vd_name = "drmfb",
+	.vd_init = vt_drmfb_init,
+	.vd_fini = vt_drmfb_fini,
+	.vd_blank = vt_drmfb_blank,
+	/*
+	 * .vd_bitblt_text is unset.
+	 *
+	 * We use the default implementation in vt(4) which copies the
+	 * characters first and bitblt_bmp them in a second step outside of the
+	 * vtbuf lock. Thus the `vd_bitblt_after_vtbuf_unlock` flag set below.
+	 * We need this because vtbuf is a spin mutex and
+	 * `vt_drmfb_bitblt_bitmap()` may sleep.
+	 */
+	.vd_bitblt_bmp = vt_drmfb_bitblt_bitmap,
+	.vd_drawrect = vt_drmfb_drawrect,
+	.vd_setpixel = vt_drmfb_setpixel,
+	.vd_invalidate_text = vt_drmfb_invalidate_text,
+	.vd_postswitch = vt_drmfb_postswitch,
+	.vd_priority = VD_PRIORITY_GENERIC+20,
+	.vd_suspend = vt_drmfb_suspend,
+	.vd_resume = vt_drmfb_resume,
+
+	/* Use vt_fb implementation */
+	.vd_fb_ioctl = vt_fb_ioctl,
+	.vd_fb_mmap = vt_fb_mmap,
+
+	.vd_bitblt_after_vtbuf_unlock = true,
+};
+
+VT_DRIVER_DECLARE(vt_drmfb, vt_drmfb_driver);
+
+void
+vt_drmfb_setpixel(struct vt_device *vd, int x, int y, term_color_t color)
+{
+	vt_drmfb_drawrect(vd, x, y, x, y, 1, color);
+}
+
+void
+vt_drmfb_drawrect(
+    struct vt_device *vd,
+    int x1, int y1, int x2, int y2, int fill,
+    term_color_t color)
+{
+	struct fb_info *fbio;
+	struct linux_fb_info *info;
+	struct fb_fillrect rect;
+
+	fbio = vd->vd_softc;
+	info = to_linux_fb_info(fbio);
+	if (info->fbops->fb_fillrect == NULL)
+		return;
+
+	KASSERT(
+	    (x2 >= x1),
+	    ("Invalid rectangle X coordinates passed to vd_drawrect: "
+	     "x1=%d > x2=%d", x1, x2));
+	KASSERT(
+	    (y2 >= y1),
+	    ("Invalid rectangle Y coordinates passed to vd_drawrect: "
+	     "y1=%d > y2=%d", y1, y2));
+	KASSERT(
+	    (fill != 0),
+	    ("`fill=0` argument to vd_drawrect unsupported in vt_drmfb"));
+
+	rect.dx = x1;
+	rect.dy = y1;
+	rect.width = x2 - x1 + 1;
+	rect.height = y2 - y1 + 1;
+	rect.color = fbio->fb_cmap[color];
+	rect.rop = ROP_COPY;
+
+	info->fbops->fb_fillrect(info, &rect);
+}
+
+void
+vt_drmfb_blank(struct vt_device *vd, term_color_t color)
+{
+	struct fb_info *fbio;
+	struct linux_fb_info *info;
+	int x1, y1, x2, y2;
+
+	fbio = vd->vd_softc;
+	info = to_linux_fb_info(fbio);
+
+	x1 = info->var.xoffset;
+	y1 = info->var.yoffset;
+	x2 = info->var.xres - 1;
+	y2 = info->var.yres - 1;
+
+	vt_drmfb_drawrect(vd, x1, y1, x2, y2, 1, color);
+}
+
+void
+vt_drmfb_bitblt_bitmap(struct vt_device *vd, const struct vt_window *vw,
+    const uint8_t *pattern, const uint8_t *mask,
+    unsigned int width, unsigned int height,
+    unsigned int x, unsigned int y, term_color_t fg, term_color_t bg)
+{
+	struct fb_info *fbio;
+	struct linux_fb_info *info;
+	struct fb_image image;
+
+	fbio = vd->vd_softc;
+	info = to_linux_fb_info(fbio);
+	if (info->fbops->fb_imageblit == NULL)
+		return;
+
+	/* Bound by right and bottom edges. */
+	if (y + height > vw->vw_draw_area.tr_end.tp_row) {
+		if (y >= vw->vw_draw_area.tr_end.tp_row)
+			return;
+		height = vw->vw_draw_area.tr_end.tp_row - y;
+	}
+	if (x + width > vw->vw_draw_area.tr_end.tp_col) {
+		if (x >= vw->vw_draw_area.tr_end.tp_col)
+			return;
+		width = vw->vw_draw_area.tr_end.tp_col - x;
+	}
+
+	image.dx = x;
+	image.dy = y;
+	image.width = width;
+	image.height = height;
+	image.fg_color = fbio->fb_cmap[fg];
+	image.bg_color = fbio->fb_cmap[bg];
+	image.depth = 1;
+	image.data = pattern;
+	image.mask = mask; // Specific to FreeBSD to display the mouse pointer.
+
+	if (!kdb_active && !KERNEL_PANICKED())
+		linux_set_current(curthread);
+
+	info->fbops->fb_imageblit(info, &image);
+}
+
+void
+vt_drmfb_postswitch(struct vt_device *vd)
+{
+	struct fb_info *fbio;
+	struct linux_fb_info *info;
+
+	fbio = vd->vd_softc;
+	info = to_linux_fb_info(fbio);
+
+	if (!kdb_active && !KERNEL_PANICKED()) {
+		taskqueue_enqueue(taskqueue_thread, &info->fb_mode_task);
+
+		/* XXX the VT_ACTIVATE IOCTL must be synchronous */
+		if (curthread->td_proc->p_pid != 0 &&
+		    taskqueue_member(taskqueue_thread, curthread) == 0)
+			taskqueue_drain(taskqueue_thread, &info->fb_mode_task);
+	} else {
+#ifdef DDB
+		db_trace_self_depth(10);
+		mdelay(1000);
+#endif
+		if (skip_ddb) {
+			spinlock_enter();
+			doadump(false);
+			EVENTHANDLER_INVOKE(shutdown_final, RB_NOSYNC);
+		}
+
+		if (vd->vd_grabwindow != NULL) {
+			if (info->fbops->fb_debug_enter)
+				info->fbops->fb_debug_enter(info);
+		} else {
+			if (info->fbops->fb_debug_leave)
+				info->fbops->fb_debug_leave(info);
+		}
+	}
+}
+
+void
+vt_drmfb_invalidate_text(struct vt_device *vd, const term_rect_t *area)
+{
+	unsigned int col, row;
+	size_t z;
+
+	for (row = area->tr_begin.tp_row; row < area->tr_end.tp_row; ++row) {
+		for (col = area->tr_begin.tp_col; col < area->tr_end.tp_col;
+		    ++col) {
+			z = row * PIXEL_WIDTH(VT_FB_MAX_WIDTH) + col;
+			if (z >= PIXEL_HEIGHT(VT_FB_MAX_HEIGHT) *
+			    PIXEL_WIDTH(VT_FB_MAX_WIDTH))
+				continue;
+			if (vd->vd_drawn)
+				vd->vd_drawn[z] = 0;
+			if (vd->vd_drawnfg)
+				vd->vd_drawnfg[z] = 0;
+			if (vd->vd_drawnbg)
+				vd->vd_drawnbg[z] = 0;
+			if (vd->vd_pos_to_flush)
+				vd->vd_pos_to_flush[z] = true;
+		}
+	}
+}
+
+static int
+vt_drmfb_init_colors(struct fb_info *info)
+{
+
+	switch (FBTYPE_GET_BPP(info)) {
+	case 8:
+		return (vt_config_cons_colors(info, COLOR_FORMAT_RGB,
+		    0x7, 5, 0x7, 2, 0x3, 0));
+	case 15:
+		return (vt_config_cons_colors(info, COLOR_FORMAT_RGB,
+		    0x1f, 10, 0x1f, 5, 0x1f, 0));
+	case 16:
+		return (vt_config_cons_colors(info, COLOR_FORMAT_RGB,
+		    0x1f, 11, 0x3f, 5, 0x1f, 0));
+	case 24:
+	case 32: /* Ignore alpha. */
+		return (vt_config_cons_colors(info, COLOR_FORMAT_RGB,
+		    0xff, 16, 0xff, 8, 0xff, 0));
+	default:
+		return (1);
+	}
+}
+
+int
+vt_drmfb_init(struct vt_device *vd)
+{
+	struct fb_info *fbio;
+	u_int margin;
+	int bg, err;
+	term_color_t c;
+
+	fbio = vd->vd_softc;
+	vd->vd_height = MIN(VT_FB_MAX_HEIGHT, fbio->fb_height);
+	margin = (fbio->fb_height - vd->vd_height) >> 1;
+	vd->vd_transpose = margin * fbio->fb_stride;
+	vd->vd_width = MIN(VT_FB_MAX_WIDTH, fbio->fb_width);
+	margin = (fbio->fb_width - vd->vd_width) >> 1;
+	vd->vd_transpose += margin * (fbio->fb_bpp / NBBY);
+	vd->vd_video_dev = fbio->fb_video_dev;
+
+	if (fbio->fb_size == 0)
+		return (CN_DEAD);
+
+	if (fbio->fb_pbase == 0 && fbio->fb_vbase == 0)
+		fbio->fb_flags |= FB_FLAG_NOMMAP;
+
+	if (fbio->fb_cmsize <= 0) {
+		err = vt_drmfb_init_colors(fbio);
+		if (err)
+			return (CN_DEAD);
+		fbio->fb_cmsize = 16;
+	}
+
+	c = TC_BLACK;
+	if (TUNABLE_INT_FETCH("teken.bg_color", &bg) != 0) {
+		if (bg == TC_WHITE)
+			bg |= TC_LIGHT;
+		c = bg;
+	}
+
+	/* Clear the screen. */
+	vd->vd_driver->vd_blank(vd, c);
+
+	return (CN_INTERNAL);
+}
+
+void
+vt_drmfb_fini(struct vt_device *vd, void *softc)
+{
+	vd->vd_video_dev = NULL;
+}
+
+int
+vt_drmfb_attach(struct fb_info *fbio)
+{
+	int ret;
+
+	ret = vt_allocate(&vt_drmfb_driver, fbio);
+
+	return (ret);
+}
+
+int
+vt_drmfb_detach(struct fb_info *fbio)
+{
+	int ret;
+
+	ret = vt_deallocate(&vt_drmfb_driver, fbio);
+
+	return (ret);
+}
+
+void
+vt_drmfb_suspend(struct vt_device *vd)
+{
+	vt_suspend(vd);
+}
+
+void
+vt_drmfb_resume(struct vt_device *vd)
+{
+	vt_resume(vd);
+}

--- a/drivers/gpu/drm/vt_drmfb.h
+++ b/drivers/gpu/drm/vt_drmfb.h
@@ -1,0 +1,44 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2013 The FreeBSD Foundation
+ * Copyright (c) 2023 Jean-Sébastien Pédron <dumbbell@FreeBSD.org>
+ *
+ * This initial software `sys/dev/vt/hw/vt_fb.h` was developed by Aleksandr
+ * Rybalko under sponsorship from the FreeBSD Foundation.
+ * This file is a copy of the initial file and is modified by Jean-Sébastien
+ * Pédron.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef _DEV_VT_HW_FB_VT_DRMFB_H_
+#define	_DEV_VT_HW_FB_VT_DRMFB_H_
+/* Generic framebuffer interface call vt_drmfb_attach to init VT(9) */
+int vt_drmfb_attach(struct fb_info *info);
+void vt_drmfb_resume(struct vt_device *vd);
+void vt_drmfb_suspend(struct vt_device *vd);
+int vt_drmfb_detach(struct fb_info *info);
+
+#endif /* _DEV_VT_HW_FB_VT_DRMFB_H_ */

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -68,7 +68,8 @@ SRCS=	drm_atomic.c \
 	drm_vblank.c \
 	drm_vblank_work.c \
 	drm_vma_manager.c \
-	linux_fb.c
+	linux_fb.c \
+	vt_drmfb.c
 
 .if !empty(KCONFIG:MDRM_FBDEV_EMULATION)
 SRCS+=	drm_fb_helper.c

--- a/include/drm/drm_fb_helper.h
+++ b/include/drm/drm_fb_helper.h
@@ -203,7 +203,6 @@ drm_fb_helper_from_client(struct drm_client_dev *client)
  * Helper define to register default implementations of drm_fb_helper
  * functions. To be used in struct fb_ops of drm drivers.
  */
-#ifdef __linux__
 #define DRM_FB_HELPER_DEFAULT_OPS \
 	.fb_check_var	= drm_fb_helper_check_var, \
 	.fb_set_par	= drm_fb_helper_set_par, \
@@ -213,10 +212,6 @@ drm_fb_helper_from_client(struct drm_client_dev *client)
 	.fb_debug_enter = drm_fb_helper_debug_enter, \
 	.fb_debug_leave = drm_fb_helper_debug_leave, \
 	.fb_ioctl	= drm_fb_helper_ioctl
-#elif defined(__FreeBSD__)
-#define DRM_FB_HELPER_DEFAULT_OPS \
-	.fb_set_par	= drm_fb_helper_set_par
-#endif
 
 #ifdef CONFIG_DRM_FBDEV_EMULATION
 void drm_fb_helper_prepare(struct drm_device *dev, struct drm_fb_helper *helper,
@@ -246,7 +241,6 @@ ssize_t drm_fb_helper_sys_read(struct fb_info *info, char __user *buf,
 ssize_t drm_fb_helper_sys_write(struct fb_info *info, const char __user *buf,
 				size_t count, loff_t *ppos);
 
-#ifdef __linux__
 void drm_fb_helper_sys_fillrect(struct fb_info *info,
 				const struct fb_fillrect *rect);
 void drm_fb_helper_sys_copyarea(struct fb_info *info,
@@ -260,15 +254,12 @@ void drm_fb_helper_cfb_copyarea(struct fb_info *info,
 				const struct fb_copyarea *area);
 void drm_fb_helper_cfb_imageblit(struct fb_info *info,
 				 const struct fb_image *image);
-#endif	/* __linux__ */
 
 void drm_fb_helper_set_suspend(struct drm_fb_helper *fb_helper, bool suspend);
 void drm_fb_helper_set_suspend_unlocked(struct drm_fb_helper *fb_helper,
 					bool suspend);
 
-#ifdef __linux__
 int drm_fb_helper_setcmap(struct fb_cmap *cmap, struct fb_info *info);
-#endif
 
 int drm_fb_helper_ioctl(struct fb_info *info, unsigned int cmd,
 			unsigned long arg);

--- a/linuxkpi/bsd/include/uapi/linux/fb.h
+++ b/linuxkpi/bsd/include/uapi/linux/fb.h
@@ -190,6 +190,9 @@ struct fb_image {
 	uint8_t  depth;
 	const char *data;
 	struct fb_cmap cmap;
+#ifdef __FreeBSD__
+	const char *mask;
+#endif
 };
 
 struct fbcurpos {

--- a/linuxkpi/bsd/include/uapi/linux/fb.h
+++ b/linuxkpi/bsd/include/uapi/linux/fb.h
@@ -32,6 +32,177 @@
 #define	FB_ROTATE_UD	2
 #define	FB_ROTATE_CCW	3
 
-#define	FBIO_WAITFORVSYNC	_IOW('F', 0x20, __u32)
+#define	FBIO_WAITFORVSYNC	_IOW('F', 0x20, uint32_t)
 
-#endif	/* _BSD_LKPI_UAPI_FB_H_ */
+#define PICOS2KHZ(a) (1000000000UL/(a))
+#define KHZ2PICOS(a) (1000000000UL/(a))
+
+#define FB_TYPE_PACKED_PIXELS		0
+#define FB_TYPE_PLANES			1
+#define FB_TYPE_INTERLEAVED_PLANES	2
+#define FB_TYPE_TEXT			3
+#define FB_TYPE_VGA_PLANES		4
+#define FB_TYPE_FOURCC			5
+
+#define FB_VISUAL_MONO01		0
+#define FB_VISUAL_MONO10		1
+#define FB_VISUAL_TRUECOLOR		2
+#define FB_VISUAL_PSEUDOCOLOR		3
+#define FB_VISUAL_DIRECTCOLOR		4
+#define FB_VISUAL_STATIC_PSEUDOCOLOR	5
+#define FB_VISUAL_FOURCC		6
+
+#define FB_ACCEL_NONE		0
+
+struct fb_fix_screeninfo {
+	char id[16];
+#ifdef __linux__
+	unsigned long smem_start;
+#elif defined(__FreeBSD__)
+	vm_paddr_t smem_start;
+#endif
+
+	uint32_t smem_len;
+	uint32_t type;
+	uint32_t type_aux;
+	uint32_t visual;
+	uint16_t xpanstep;
+	uint16_t ypanstep;
+	uint16_t ywrapstep;
+	uint32_t line_length;
+	unsigned long mmio_start;
+
+	uint32_t mmio_len;
+	uint32_t accel;
+
+	uint16_t capabilities;
+	uint16_t reserved[2];
+};
+
+struct fb_bitfield {
+	uint32_t offset;
+	uint32_t length;
+	uint32_t msb_right;
+};
+
+#define FB_ACTIVATE_NOW		0
+
+#define FB_ACCELF_TEXT		1
+
+struct fb_var_screeninfo {
+	uint32_t xres;
+	uint32_t yres;
+	uint32_t xres_virtual;
+	uint32_t yres_virtual;
+	uint32_t xoffset;
+	uint32_t yoffset;
+
+	uint32_t bits_per_pixel;
+	uint32_t grayscale;
+
+	struct fb_bitfield red;
+	struct fb_bitfield green;
+	struct fb_bitfield blue;
+	struct fb_bitfield transp;
+
+	uint32_t nonstd;
+
+	uint32_t activate;
+
+	uint32_t height;
+	uint32_t width;
+
+	uint32_t accel_flags;
+
+	uint32_t pixclock;
+	uint32_t left_margin;
+	uint32_t right_margin;
+	uint32_t upper_margin;
+	uint32_t lower_margin;
+	uint32_t hsync_len;
+	uint32_t vsync_len;
+	uint32_t sync;
+	uint32_t vmode;
+	uint32_t rotate;
+	uint32_t colorspace;
+	uint32_t reserved[4];
+};
+
+struct fb_cmap {
+	uint32_t start;
+	uint32_t len;
+	uint16_t *red;
+	uint16_t *green;
+	uint16_t *blue;
+	uint16_t *transp;
+};
+
+/* VESA Blanking Levels */
+#define VESA_NO_BLANKING        0
+#define VESA_VSYNC_SUSPEND      1
+#define VESA_HSYNC_SUSPEND      2
+#define VESA_POWERDOWN          3
+
+enum {
+	FB_BLANK_UNBLANK       = VESA_NO_BLANKING,
+	FB_BLANK_NORMAL        = VESA_NO_BLANKING + 1,
+	FB_BLANK_VSYNC_SUSPEND = VESA_VSYNC_SUSPEND + 1,
+	FB_BLANK_HSYNC_SUSPEND = VESA_HSYNC_SUSPEND + 1,
+	FB_BLANK_POWERDOWN     = VESA_POWERDOWN + 1
+};
+
+struct fb_vblank {
+	uint32_t flags;
+	uint32_t count;
+	uint32_t vcount;
+	uint32_t hcount;
+	uint32_t reserved[4];
+};
+
+#define ROP_COPY 0
+#define ROP_XOR  1
+
+struct fb_copyarea {
+	uint32_t dx;
+	uint32_t dy;
+	uint32_t width;
+	uint32_t height;
+	uint32_t sx;
+	uint32_t sy;
+};
+
+struct fb_fillrect {
+	uint32_t dx;
+	uint32_t dy;
+	uint32_t width;
+	uint32_t height;
+	uint32_t color;
+	uint32_t rop;
+};
+
+struct fb_image {
+	uint32_t dx;
+	uint32_t dy;
+	uint32_t width;
+	uint32_t height;
+	uint32_t fg_color;
+	uint32_t bg_color;
+	uint8_t  depth;
+	const char *data;
+	struct fb_cmap cmap;
+};
+
+struct fbcurpos {
+	uint16_t x, y;
+};
+
+struct fb_cursor {
+	uint16_t set;
+	uint16_t enable;
+	uint16_t rop;
+	const char *mask;
+	struct fbcurpos hot;
+	struct fb_image	image;
+};
+
+#endif

--- a/linuxkpi/gplv2/include/linux/fb.h
+++ b/linuxkpi/gplv2/include/linux/fb.h
@@ -104,6 +104,4 @@ is_firmware_framebuffer(struct apertures_struct *a __unused)
 int linux_fb_get_options(const char *name, char **option);
 #define	fb_get_options	linux_fb_get_options
 
-void vt_unfreeze_main_vd(void);
-
 #endif /* __LINUX_FB_H_ */

--- a/linuxkpi/gplv2/include/linux/fb.h
+++ b/linuxkpi/gplv2/include/linux/fb.h
@@ -144,6 +144,7 @@ struct linux_fb_info {
 #ifdef __FreeBSD__
 	struct fb_info fbio;
 	device_t fb_bsddev;
+	struct task fb_mode_task;
 #endif
 } __aligned(sizeof(long));
 

--- a/linuxkpi/gplv2/include/linux/fb.h
+++ b/linuxkpi/gplv2/include/linux/fb.h
@@ -18,32 +18,99 @@ struct linux_fb_info;
 struct videomode;
 struct vm_area_struct;
 
-#define KHZ2PICOS(a) (1000000000UL/(a))
-
-struct fb_fix_screeninfo {
-	vm_paddr_t	smem_start;
-	uint32_t	smem_len;
-	uint32_t	line_length;
-};
-
-struct fb_var_screeninfo {
-	int	xres;
-	int	yres;
-	int	bits_per_pixel;
+struct fb_blit_caps {
+	u32 x;
+	u32 y;
+	u32 len;
+	u32 flags;
 };
 
 struct fb_ops {
 	/* open/release and usage marking */
 	struct module *owner;
+	int (*fb_open)(struct linux_fb_info *info, int user);
+	int (*fb_release)(struct linux_fb_info *info, int user);
+
+	/* For framebuffers with strange non linear layouts or that do not
+	 * work with normal memory mapped access
+	 */
+	ssize_t (*fb_read)(struct linux_fb_info *info, char __user *buf,
+			   size_t count, loff_t *ppos);
+	ssize_t (*fb_write)(struct linux_fb_info *info, const char __user *buf,
+			    size_t count, loff_t *ppos);
+
+	/* checks var and eventually tweaks it to something supported,
+	 * DO NOT MODIFY PAR */
+	int (*fb_check_var)(struct fb_var_screeninfo *var, struct linux_fb_info *info);
 
 	/* set the video mode according to info->var */
 	int (*fb_set_par)(struct linux_fb_info *info);
 
+	/* set color register */
+	int (*fb_setcolreg)(unsigned regno, unsigned red, unsigned green,
+			    unsigned blue, unsigned transp, struct linux_fb_info *info);
+
+	/* set color registers in batch */
+	int (*fb_setcmap)(struct fb_cmap *cmap, struct linux_fb_info *info);
+
+	/* blank display */
+	int (*fb_blank)(int blank, struct linux_fb_info *info);
+
+	/* pan display */
+	int (*fb_pan_display)(struct fb_var_screeninfo *var, struct linux_fb_info *info);
+
+	/* Draws a rectangle */
+	void (*fb_fillrect) (struct linux_fb_info *info, const struct fb_fillrect *rect);
+	/* Copy data from area to another */
+	void (*fb_copyarea) (struct linux_fb_info *info, const struct fb_copyarea *region);
+	/* Draws a image to the display */
+	void (*fb_imageblit) (struct linux_fb_info *info, const struct fb_image *image);
+
+	/* Draws cursor */
+	int (*fb_cursor) (struct linux_fb_info *info, struct fb_cursor *cursor);
+
+	/* wait for blit idle, optional */
+	int (*fb_sync)(struct linux_fb_info *info);
+
+	/* perform fb specific ioctl (optional) */
+	int (*fb_ioctl)(struct linux_fb_info *info, unsigned int cmd,
+			unsigned long arg);
+
+	/* Handle 32bit compat ioctl (optional) */
+	int (*fb_compat_ioctl)(struct linux_fb_info *info, unsigned cmd,
+			unsigned long arg);
+
+	/* perform fb specific mmap */
+	int (*fb_mmap)(struct linux_fb_info *info, struct vm_area_struct *vma);
+
+	/* get capability given var */
+	void (*fb_get_caps)(struct linux_fb_info *info, struct fb_blit_caps *caps,
+			    struct fb_var_screeninfo *var);
+
 	/* teardown any resources to do with this framebuffer */
 	void (*fb_destroy)(struct linux_fb_info *info);
+
+	/* called at KDB enter and leave time to prepare the console */
+	int (*fb_debug_enter)(struct linux_fb_info *info);
+	int (*fb_debug_leave)(struct linux_fb_info *info);
 };
 
+/*
+ * Hide smem_start in the FBIOGET_FSCREENINFO IOCTL. This is used by modern DRM
+ * drivers to stop userspace from trying to share buffers behind the kernel's
+ * back. Instead dma-buf based buffer sharing should be used.
+ */
+#define FBINFO_HIDE_SMEM_START  0x200000
+
+
 struct linux_fb_info {
+	int flags;
+	/*
+	 * -1 by default, set to a FB_ROTATE_* value by the driver, if it knows
+	 * a lcd is not mounted upright and fbcon should rotate to compensate.
+	 */
+	int fbcon_rotate_hint;
+
 	struct fb_var_screeninfo var;	/* Current var */
 	struct fb_fix_screeninfo fix;	/* Current fix */
 
@@ -72,8 +139,12 @@ struct linux_fb_info {
 		} ranges[0];
 	} *apertures;
 
+	bool skip_vt_switch; /* no VT switch on suspend/resume required */
+
+#ifdef __FreeBSD__
 	struct fb_info fbio;
 	device_t fb_bsddev;
+#endif
 } __aligned(sizeof(long));
 
 static inline struct apertures_struct *alloc_apertures(unsigned int max_num) {
@@ -84,6 +155,24 @@ static inline struct apertures_struct *alloc_apertures(unsigned int max_num) {
 	a->count = max_num;
 	return a;
 }
+
+    /*
+     *  `Generic' versions of the frame buffer device operations
+     */
+
+extern void cfb_fillrect(struct linux_fb_info *info, const struct fb_fillrect *rect);
+extern void cfb_copyarea(struct linux_fb_info *info, const struct fb_copyarea *area);
+extern void cfb_imageblit(struct linux_fb_info *info, const struct fb_image *image);
+/*
+ * Drawing operations where framebuffer is in system RAM
+ */
+extern void sys_fillrect(struct linux_fb_info *info, const struct fb_fillrect *rect);
+extern void sys_copyarea(struct linux_fb_info *info, const struct fb_copyarea *area);
+extern void sys_imageblit(struct linux_fb_info *info, const struct fb_image *image);
+extern ssize_t fb_sys_read(struct linux_fb_info *info, char __user *buf,
+			   size_t count, loff_t *ppos);
+extern ssize_t fb_sys_write(struct linux_fb_info *info, const char __user *buf,
+			    size_t count, loff_t *ppos);
 
 int linux_register_framebuffer(struct linux_fb_info *fb_info);
 int linux_unregister_framebuffer(struct linux_fb_info *fb_info);


### PR DESCRIPTION
This patch series replaces our current vt(4) integration layer with a new one relying entirely on `drm_fb_helper.c`.

### Why

In Linux 5.17, the amdgpu driver relies entirely on `drm_fb_helper` to handle its framebuffer. Indeed, the framebuffer-specific code is removed.

Also in Linux 5.17, something changed in the i915 driver. I don't know exactly what, but the memory region passed to vt(4) and `vt_fb` isn't the one displayed on the screen. Therefore, all writes made by `vt_fb` leads to no changes on the screen and the computer looks frozen (that's not the case). However, when I vt-switch to another tty, the screen is refreshed to show the content of the tty active *before* the switch. Switching tty is the only time `vt_fb` calls into DRM. There is enough evidence that the i915 driver now assumes that the framebuffer is accessed like `drm_fb_helper` does it, i.e. like a Linux fbdev device.

The symptoms are the same when we enable PSR in the i915 driver (`enable_psr=1`). It's currently turned off by default on FreeBSD, unlike Linux.

Unfortunately, our vt(4) integration is way more basic than than Linux' fbdev and doesn't reproduce the behavior of an fbdev device.

### How

The branch contains two major parts:
1. It uncomments the code in `drm_fb_helper.c` and related code in DRM drivers. This makes sure that the code compiles, even though it is not used at that point.
2. It introduces a new vt(4) backend called `vt_drmfb`, compiled in `drm.ko`. This new backend is responsible for bridging the vt(4) callbacks (upper layer) and the fbdev callbacks (lower layer).

This work relies on patches to freebsd-src. They are available in the [`linuxkpi-updates-for-drm` branch in my freebsd-src fork](https://github.com/dumbbell/freebsd-src/commits/linuxkpi-updates-for-drm). Patches were submitted for reviews to Phabricator:
* ~~https://reviews.freebsd.org/D42054~~
* ~~https://reviews.freebsd.org/D42056~~
* ~~https://reviews.freebsd.org/D42057~~
* ~~https://reviews.freebsd.org/D42750~~
* ~~https://reviews.freebsd.org/D42751~~
* ~~https://reviews.freebsd.org/D42752~~

### TODO

- [x] Check how kldunload(8) will behave.
- [x] Fix the nested locking issue between `vtbuf_lock()` in `vt_flush()` and `WQ_EXEC_LOCK()` in `schedule_work()` in linuxkpi (sleepable lock acquired inside a non-sleepable lock section).
- [x] Add support for vt(4) `bitblt_image` callback mask argument; there is no equivalent on the fbdev side.

This work is required by the Linux 5.17 backport (#236).

Fixes #17.