### PR TITLE
Add linuxkpi_version.mk for cross-project version tracking

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -6,6 +6,7 @@ DRM= ${.CURDIR:H:H}/drivers/gpu/drm
 KMOD=	amdgpu
 
 .include "../../kconfig.mk"
+.include "../../linuxkpi_version.mk"
 
 .if !empty(KCONFIG:MDRM_AMD_DC_DCN*)
 _dml=	${SRCDIR}/display/dc/dml \
@@ -795,7 +796,7 @@ CFLAGS+= -I${SRCDIR}/pm/swsmu/smu13
 CFLAGS+= -I${DRM}/scheduler
 
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
-CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=amdgpu_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD} -DLINUXKPI_VERSION=51600
+CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=amdgpu_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD}
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 SRCS+=	device_if.h vnode_if.h bus_if.h pci_if.h pci_iov_if.h device_if.h iicbus_if.h opt_drm.h \

--- a/dmabuf/Makefile
+++ b/dmabuf/Makefile
@@ -3,6 +3,7 @@ SRCDIR=	${.CURDIR:H}/drivers/dma-buf
 .PATH:	${SRCDIR}
 
 .include "../kconfig.mk"
+.include "../linuxkpi_version.mk"
 
 KMOD=	dmabuf
 SRCS=	dma-buf-kmod.c \
@@ -26,7 +27,6 @@ CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include # fallback to dummy
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/dummy/include
 
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
-CFLAGS+= -DLINUXKPI_VERSION=51600
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 CWARNFLAGS.dma-buf.c+=	-Wno-pointer-arith

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -5,6 +5,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm
 .PATH:	${SRCDIR} ${SRCDIR}/scheduler
 
 .include "../kconfig.mk"
+.include "../linuxkpi_version.mk"
 
 KMOD=	drm
 SRCS=	drm_atomic.c \
@@ -123,7 +124,7 @@ CFLAGS+= -I${.CURDIR:H}/include/uapi
 CFLAGS+= -I${SRCDIR:H}
 
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
-CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=drm_' -DDRM_SYSCTL_PARAM_PREFIX=_dri -DLINUXKPI_VERSION=51600
+CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=drm_' -DDRM_SYSCTL_PARAM_PREFIX=_dri
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 SRCS+=	device_if.h \

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -11,6 +11,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/i915
 	${SRCDIR}/pxp
 
 .include "../kconfig.mk"
+.include "../linuxkpi_version.mk"
 
 KMOD=	i915kms
 SRCS=	\
@@ -286,7 +287,7 @@ CFLAGS+= -I${.CURDIR:H}/include/uapi
 CFLAGS+= -I${SRCDIR:H:H} -I${SRCDIR} -I${SRCDIR}/display
 
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
-CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=i915_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD} -DLINUXKPI_VERSION=51600
+CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=i915_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD}
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 SRCS	+=			\

--- a/linuxkpi_version.mk
+++ b/linuxkpi_version.mk
@@ -1,0 +1,9 @@
+# Definition of LINUXKPI_VERSION
+#
+# This is used to track linuxkpi compatability with
+# the source tree and external components such as
+# nvidia-drm
+
+LINUXKPI_VERSION_NUMBER=	51600
+
+CFLAGS+=	-DLINUXKPI_VERSION=${LINUXKPI_VERSION_NUMBER}

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -5,6 +5,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/radeon
 .PATH:	${SRCDIR}
 
 .include "../kconfig.mk"
+.include "../linuxkpi_version.mk"
 
 KMOD=	radeonkms
 SRCS=	atom.c \
@@ -134,7 +135,7 @@ CFLAGS+= -I${SRCDIR:H:H}
 CFLAGS+= -I${SRCDIR:H}/amd/include
 
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
-CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=radeon_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD} -DLINUXKPI_VERSION=51600
+CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=radeon_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD}
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 CFLAGS.gcc+= -Wno-redundant-decls -Wno-cast-qual -Wno-unused-but-set-variable \

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -5,6 +5,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/ttm
 .PATH:	${SRCDIR} ${SRCDIR}/..
 
 .include "../kconfig.mk"
+.include "../linuxkpi_version.mk"
 
 KMOD=	ttm
 SRCS=	ttm_bo.c \
@@ -38,7 +39,7 @@ CFLAGS+= -I${.CURDIR:H}/include/uapi
 CFLAGS+= -I${SRCDIR:H:H}
 
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
-CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=ttm_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD} -DLINUXKPI_VERSION=51600
+CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=ttm_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD}
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 SRCS+=	device_if.h \


### PR DESCRIPTION
One of this issues with running nvidia-drm against drm-kmod's master branch is that there are some mismatches in compatibility that require the `LINUXKPI_VERSION` macro to be defined. Here is an example of a build breaking due to nvidia-drm not having that defined:

https://cirrus-ci.com/task/4762004506804224

Currently I added `-DLINUXKPI_VERSION=51600` to nvidia-drm to get builds against master working, but we need a better solution long term. nvidia-drm needs a way to get this directly from drm-kmod, since it may be different between master, `5.15-lts`, `5.10-lts`, etc.

I took a stab at a solution and came up with this: a new `linuxkpi_version.mk` makefile that nvidia-drm can include to get the proper version defined and added to its `CFLAGS`. I tested that both nvidia-drm and drm-kmod built with this, although I haven't pushed the nvidia-drm change using it yet. This patch will resolve the issue, but I'm open to alternatives if this doesn't look good.