### PR TITLE
Remove dep on nonexistent opt_compat.h

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -800,7 +800,7 @@ CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=amdgpu_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD}
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 SRCS+=	device_if.h vnode_if.h bus_if.h pci_if.h pci_iov_if.h device_if.h iicbus_if.h opt_drm.h \
-        opt_vm.h opt_compat.h opt_syscons.h opt_acpi.h
+        opt_vm.h opt_syscons.h opt_acpi.h
 
 .include <bsd.kmod.mk>
 

--- a/amd/amdkfd/Makefile
+++ b/amd/amdkfd/Makefile
@@ -59,7 +59,7 @@ CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=amdkfd_'
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
 
 SRCS+=	device_if.h vnode_if.h bus_if.h pci_if.h pci_iov_if.h device_if.h iicbus_if.h opt_drm.h \
-	opt_vm.h opt_compat.h opt_syscons.h
+	opt_vm.h opt_syscons.h
 
 .include <bsd.kmod.mk>
 

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -139,7 +139,6 @@ SRCS+=	device_if.h \
 	opt_syscons.h \
 	opt_drm.h \
 	opt_vm.h \
-	opt_compat.h \
 	opt_syscons.h
 
 .if ${MACHINE_CPUARCH} == "powerpc"

--- a/dummygfx/Makefile
+++ b/dummygfx/Makefile
@@ -26,7 +26,6 @@ CFLAGS+= -include ${SRCDIR:H}/drivers/gpu/drm/drm_os_config.h
 
 SRCS	+=			\
 	opt_acpi.h		\
-	opt_compat.h		\
 	opt_drm.h		\
 	opt_platform.h		\
 	opt_splash.h		\

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -292,7 +292,6 @@ CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 SRCS	+=			\
 	opt_acpi.h		\
-	opt_compat.h		\
 	opt_drm.h		\
 	opt_syscons.h		\
 	acpi_if.h		\

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -142,7 +142,7 @@ CFLAGS.gcc+= -Wno-redundant-decls -Wno-cast-qual -Wno-unused-but-set-variable \
 	-Wno-maybe-uninitialized
 
 SRCS+=	device_if.h vnode_if.h bus_if.h pci_if.h pci_iov_if.h device_if.h iicbus_if.h opt_drm.h \
-	opt_vm.h opt_compat.h opt_syscons.h
+	opt_vm.h opt_syscons.h
 
 .include <bsd.kmod.mk>
 

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -51,7 +51,6 @@ SRCS+=	device_if.h \
 	iicbus_if.h \
 	opt_drm.h \
 	opt_vm.h \
-	opt_compat.h \
 	opt_syscons.h
 
 .if ${MACHINE_CPUARCH} == "powerpc"


### PR DESCRIPTION
This file does not exist and is not used anywhere, and depending on it causes `WITH_META_MODE` to never do the fast incremental build.

```
drm-kmod❯ ls -la  /usr/home/val/os/target/base-obj/usr/home/val/os/base/amd64.amd64/sys/GENERIC/ | rg opt_c
-rw-r--r--  1 val  val          0 May  5 06:20 opt_callout_profiling.h
-rw-r--r--  1 val  val          0 May  5 06:20 opt_cam.h
-rw-r--r--  1 val  val         49 May  5 06:20 opt_capsicum.h
-rw-r--r--  1 val  val          0 May  5 06:20 opt_carp.h
-rw-r--r--  1 val  val          0 May  5 06:20 opt_cc.h
-rw-r--r--  1 val  val          0 May  5 06:20 opt_cd.h
-rw-r--r--  1 val  val          0 May  5 06:20 opt_cfi.h
-rw-r--r--  1 val  val          0 May  5 06:20 opt_clock.h
-rw-r--r--  1 val  val         30 May  5 06:20 opt_config.h
-rw-r--r--  1 val  val         17 May  5 06:20 opt_cpu.h
-rw-r--r--  1 val  val          0 May  5 06:20 opt_cy_pci_fastintr.h
```