### PR TITLE
drm_os_freebsd.h: Define CONFIG_COMPAT

### DIFF
--- a/drivers/gpu/drm/drm_os_freebsd.h
+++ b/drivers/gpu/drm/drm_os_freebsd.h
@@ -32,6 +32,10 @@ struct vt_kms_softc {
 #define	KTR_DRM		KTR_DEV
 #define	KTR_DRM_REG	KTR_SPARE3
 
+#if defined(__amd64__)
+#define CONFIG_COMPAT
+#endif
+
 MALLOC_DECLARE(DRM_MEM_DMA);
 MALLOC_DECLARE(DRM_MEM_DRIVER);
 MALLOC_DECLARE(DRM_MEM_KMS);


### PR DESCRIPTION
This adds a definition of `CONFIG_COMPAT`, which controls whether or not 32-bit compatibility gets enabled during compilation. This unbreaks steam on nvidia-drm.

nvidia-drm declares its `compat_ioctl` file operation to`drm_compat_ioctl`, but `drm_compat_ioctl` is macro'd away as NULL when `CONFIG_COMPAT` is not defined. This causes 32-bit linux programs to go through the 64-bit ioctl functions, which makes them all segfault. An easy test program is `/compat/linux/bin/glxinfo32`, but steam is the real motivation here.

`CONFIG_COMPAT` is declared on amd64, I tried to use `COMPAT_FREEBSD32` but that doesn't seem to be present unless you're in the main FreeBSD source tree's build.