### PR TITLE
drm-kmod 5.15-lts: make LINT kernels compile

### DIFF
--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_trace_freebsd.h
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_trace_freebsd.h
@@ -312,7 +312,7 @@ static inline void trace_ ## name(const struct drm_atomic_state *state) \
 	CTR3(KTR_DRM, \
 	    #name "[1/2] " \
 	    "state=%p allow_modeset=%d legacy_cursor_update=%d", \
-	    state, allow_modeset, legacy_cursor_update); \
+	    state_state, allow_modeset, legacy_cursor_update); \
 	CTR4(KTR_DRM, \
 	    #name "[2/2] " \
 	    "async_update=%d duplicated=%d num_connector=%d " \
@@ -361,7 +361,7 @@ trace_amdgpu_dm_atomic_check_finish(
 	CTR4(KTR_DRM, \
 	    "amdgpu_dm_atomic_check_finish " \
 	    "state=%p res=%d async_update=%d allow_modeset=%d",
-	    state, res, async_update, allow_modeset);
+	    state_state, res, async_update, allow_modeset);
 }
 
 /* TRACE_EVENT(amdgpu_dm_dc_pipe_state, */
@@ -491,6 +491,7 @@ trace_amdgpu_dm_dc_clocks_state(const struct dc_clocks *clk)
 
 	dispclk_khz = clk->dispclk_khz;
 	dppclk_khz = clk->dppclk_khz;
+	disp_dpp_voltage_level_khz = -1;
 	dcfclk_khz = clk->dcfclk_khz;
 	socclk_khz = clk->socclk_khz;
 	dcfclk_deep_sleep_khz = clk->dcfclk_deep_sleep_khz;

--- a/drivers/gpu/drm/i915/i915_trace.h
+++ b/drivers/gpu/drm/i915/i915_trace.h
@@ -185,8 +185,9 @@ trace_switch_mm(void *ring, void *to) {
 }
 
 #define	trace_i915_context(ctx) \
-    CTR3(KTR_DRM, \
-	__func__ " dev=%u, ctx=%p, ctx_vm=%p", \
+    CTR4(KTR_DRM, \
+	"%s dev=%u, ctx=%p, ctx_vm=%p", \
+	__func__, \
 	ctx->i915->drm.primary->index, \
 	ctx, \
 	rcu_access_pointer(ctx->vm))
@@ -204,8 +205,9 @@ trace_i915_context_free(struct i915_gem_context *ctx)
 }
 
 #define	trace_intel_context(ctx) \
-    CTR5(KTR_DRM, \
-	__func__ " guc_id=%d, pin_count=%d sched_state=0x%x,0x%x, guc_prio=%u", \
+    CTR6(KTR_DRM, \
+	"%s guc_id=%d, pin_count=%d sched_state=0x%x,0x%x, guc_prio=%u", \
+	__func__, \
 	ctx->guc_id, \
 	atomic_read(&ctx->pin_count), \
 	ctx->guc_state.sched_state, \
@@ -404,14 +406,19 @@ trace_intel_frontbuffer_flush(unsigned int frontbuffer_bits, unsigned int origin
 }
 
 #define	trace_i915_request(req) \
-    CTR6(KTR_DRM, \
-	__func__ " dev=%u, engine=%u:%u, ctx=%llu, seqno=%u, tail=%u", \
+do { \
+    CTR5(KTR_DRM, \
+	"%s dev=%u, engine=%u:%u, ctx=%llu", \
+	__func__, \
 	req->engine->i915->drm.primary->index, \
 	req->engine->uabi_class, \
 	req->engine->uabi_instance, \
-	req->fence.context, \
+	req->fence.context); \
+    CTR2(KTR_DRM, \
+	"seqno=%u, tail=%u", \
 	req->fence.seqno, \
-	req->tail)
+	req->tail); \
+} while(0)
 
 static inline void
 trace_i915_request_add(struct i915_request *req)


### PR DESCRIPTION
Around various optional KTR macro CTR calls unused variables were used. Initialise the variable, use the local variable (otherwise set but not used) rather than the one passed in.
Also __func__ is not a string literal which can be concatenated to a string, so use %s in the format string and (if needed) split up the CTR call into two calls.

Sponsored by:	The FreeBSD Foundation (MFC wifi bits w/o breaking the build)