### PR TITLE
drmcheckapplied: Use author date to reduce false positives

### DIFF
--- a/scripts/drmcheckapplied
+++ b/scripts/drmcheckapplied
@@ -18,7 +18,7 @@ mkdir -p "$1"/alreadyapplied/
 scriptdir=$(dirname "$0")
 log="$scriptdir/log.txt"
 
-git log --oneline > "$log"
+git log --pretty=format:'%aD %s' > "$log"
 
 for file in "$1"/*.patch; do
 	subject=$("$scriptdir/extract-commit-title-from-patch.awk" "$file")

--- a/scripts/extract-commit-title-from-patch.awk
+++ b/scripts/extract-commit-title-from-patch.awk
@@ -1,6 +1,12 @@
 #!/usr/bin/env -S awk -f
 # vim:sw=2:et:
 
+/^Date:/ {
+  date = $0;
+  sub(/^Date: /, "", date);
+  next;
+}
+
 /^Subject:/ {
   title = $0;
   sub(/.?*\] /, "", title);
@@ -16,7 +22,7 @@
 
 {
   if (title) {
-    print title;
+    print date, title;
     exit;
   }
 }


### PR DESCRIPTION
## Why

Sometimes, a commit subject is used by several commits, so this property alone is not enough to discriminate already applied patches.

## How

By using the commit date in addition to the subject, we are sure the combination is unique.