### PR TITLE
adjust default value for i915 GPU reset

### DIFF
--- a/drivers/gpu/drm/i915/i915_params.h
+++ b/drivers/gpu/drm/i915/i915_params.h
@@ -78,7 +78,7 @@ struct drm_printer;
 	param(bool, memtest, false, 0400) \
 	param(int, mmio_debug, -IS_ENABLED(CONFIG_DRM_I915_DEBUG_MMIO), 0600) \
 	param(int, edp_vswing, 0, 0400) \
-	param(unsigned int, reset, 3, 0600) \
+	param(unsigned int, reset, 2, 0600) \
 	param(unsigned int, inject_probe_failure, 0, 0) \
 	param(int, fastboot, -1, 0600) \
 	param(int, enable_dpcd_backlight, -1, 0600) \


### PR DESCRIPTION
The default value was adjusted with commit d78380d, but forgotten to document it in i915_params.c.
Since commit 06892ac, however, the value 3 practically no longer exists. This means that the default value can be set to 2 again, as before.