### PR TITLE
drm/i915: fix build for __FreeBSD_version >= 1500015

### DIFF
--- a/drivers/gpu/drm/i915/intel_freebsd.c
+++ b/drivers/gpu/drm/i915/intel_freebsd.c
@@ -73,10 +73,15 @@ bsd_intel_pci_bus_release_mem(device_t dev, int rid, void *res)
 	device_t vga;
 
 	vga = device_get_parent(dev);
+#if __FreeBSD_version < 1500015
 	BUS_DEACTIVATE_RESOURCE(device_get_parent(vga),
 	    dev, SYS_RES_MEMORY, rid, res);
 	BUS_RELEASE_RESOURCE(device_get_parent(vga),
 	    dev, SYS_RES_MEMORY, rid, res);
+#else
+	BUS_DEACTIVATE_RESOURCE(device_get_parent(vga), dev, res);
+	BUS_RELEASE_RESOURCE(device_get_parent(vga), dev, res);
+#endif
 }
 
 bool


### PR DESCRIPTION
FreeBSD removed `type` and `rid` arguments from bus_*.

[BUS_DEACTIVATE_RESOURCE](https://cgit.freebsd.org/src/commit/?id=2baed46e85d33b1f99e6f96033acc85a9a6fbba4)
[BUS_RELEASE_RESOURCE](https://cgit.freebsd.org/src/commit/?id=9dbf5b0e6876d8c93890754bcc9c748339de79c0)