### PR TITLE
linuxkpi: Add definition of THIS_MODULE

### DIFF
--- a/drivers/gpu/drm/drm_os_freebsd.c
+++ b/drivers/gpu/drm/drm_os_freebsd.c
@@ -176,6 +176,9 @@ static moduledata_t drm_mod = {
 	0
 };
 
+// Workaround for THIS_MODULE. Since drm.ko doesn't use LKPI_DRIVER_MODULE we
+// need to manually create the global variable that THIS_MODULE points at.
+char *THIS_MODULE_VAL = KBUILD_MODNAME;
 DECLARE_MODULE(drmn, drm_mod, SI_SUB_DRIVERS, SI_ORDER_FIRST);
 MODULE_VERSION(drmn, 2);
 #ifdef CONFIG_AGP

--- a/drivers/gpu/drm/ttm/ttm_module.c
+++ b/drivers/gpu/drm/ttm/ttm_module.c
@@ -98,6 +98,9 @@ MODULE_AUTHOR("Thomas Hellstrom, Jerome Glisse");
 MODULE_DESCRIPTION("TTM memory manager subsystem (for DRM device)");
 MODULE_LICENSE("GPL and additional rights");
 #elif defined(__FreeBSD__)
+// Workaround for THIS_MODULE. Since ttm.ko doesn't use LKPI_DRIVER_MODULE we
+// need to manually create the global variable that THIS_MODULE points at.
+char *THIS_MODULE_VAL = KBUILD_MODNAME;
 MODULE_VERSION(ttm, 1);
 #ifdef CONFIG_AGP
 MODULE_DEPEND(ttm, agp, 1, 1, 1);

--- a/linuxkpi/bsd/include/linux/module.h
+++ b/linuxkpi/bsd/include/linux/module.h
@@ -4,8 +4,20 @@
 #include <sys/param.h>
 #include <sys/module.h>
 
-#include_next <linux/module.h>
+// We need to create a unique variable name that we can make a global of and
+// point THIS_MODULE at. We can't use KBUILD_MODNAME as it is a string literal,
+// so instead we use LINUXKPI_PARAM_PREFIX which also is the name of the
+// module.
+#define THIS_MODULE_CONCAT_SUB(a, b) a##b
+#define THIS_MODULE_CONCAT(...) THIS_MODULE_CONCAT_SUB(__VA_ARGS__)
+#define THIS_MODULE_VAL THIS_MODULE_CONCAT(__this_module_, LINUXKPI_PARAM_PREFIX)
+extern char *THIS_MODULE_VAL;
 
+#if __FreeBSD_version >= 1500018
+#define THIS_MODULE ((struct module *)&THIS_MODULE_VAL)
+#endif
+
+#include_next <linux/module.h>
 
 #define	LKPI_DRIVER_MODULE(mod, init, exit)				\
 	static int mod##_evh(module_t m, int e, void *a)		\
@@ -25,6 +37,7 @@
 		 .name = #mod,						\
 		 .evhand = mod##_evh,					\
 		};							\
+	char *THIS_MODULE_VAL = KBUILD_MODNAME;	\
 	DECLARE_MODULE(mod, mod##_md, SI_SUB_DRIVERS, SI_ORDER_ANY);
 
 


### PR DESCRIPTION
This adds a definition of `THIS_MODULE` during `LKPI_DRIVER_MODULE`. We need to do this to have a global to point `THIS_MODULE` at, which helps DRM drivers check if they have the same owner. The base linuxkpi code ensures that the contents of THIS_MODULE are never read, so we point it at KBUILD_MODNAME for ease of debugging. There are a couple special cases where I had to manually create the global to point `THIS_MODULE` at.

This solves panics such as: https://github.com/amshafer/nvidia-driver/issues/21

See: https://reviews.freebsd.org/D44306
This should not be merged until the base review lands so we know what `__FreeBSD_version` to filter against.