### PR TITLE
amdgpu: disable CTF

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -5,6 +5,13 @@ DRM= ${.CURDIR:H:H}/drivers/gpu/drm
 
 KMOD=	amdgpu
 
+#
+# Work around ctfmerge(1) segfaults with recent amdgpu.ko
+#
+# https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276828
+#
+MK_CTF=	no
+
 .include "../../kconfig.mk"
 .include "../../linuxkpi_version.mk"
 


### PR DESCRIPTION
This is a workaround to deal with the ctfmerge(1) utility segfaulting after the update to drm 6.6. See the FreeBSD bug report:

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276828

This is reproducible in my environment, but I have no idea if others are affected.