### PR TITLE
i915: chase new-bus

### DIFF
--- a/drivers/gpu/drm/i915/i915_drv.c
+++ b/drivers/gpu/drm/i915/i915_drv.c
@@ -234,10 +234,16 @@ intel_teardown_mchbar(struct drm_i915_private *dev_priv)
 
 		vga = device_get_parent(dev_priv->drm.dev->bsddev);
 		BUS_DEACTIVATE_RESOURCE(device_get_parent(vga),
-		    dev_priv->drm.dev->bsddev, SYS_RES_MEMORY, dev_priv->mch_res_rid,
+		    dev_priv->drm.dev->bsddev,
+#if __FreeBSD_version < 1500015
+		    SYS_RES_MEMORY, dev_priv->mch_res_rid,
+#endif
 		    dev_priv->mch_res.bsd_res);
 		BUS_RELEASE_RESOURCE(device_get_parent(vga),
-		    dev_priv->drm.dev->bsddev, SYS_RES_MEMORY, dev_priv->mch_res_rid,
+		    dev_priv->drm.dev->bsddev,
+#if __FreeBSD_version < 1500015
+		    SYS_RES_MEMORY, dev_priv->mch_res_rid,
+#endif
 		    dev_priv->mch_res.bsd_res);
 		dev_priv->mch_res.bsd_res = NULL;
 	}


### PR DESCRIPTION
Chase base 9dbf5b0e6876 ("new-bus: Remove the 'rid' and 'type' arguments from BUS_RELEASE_RESOURCE") and base 2baed46e85d3 ("new-bus: Remove the 'rid' and 'type' arguments from BUS_*ACTIVATE_RESOURCE")
```
[...]
/tmp/drm-kmod/drivers/gpu/drm/i915/i915_drv.c:240:50: error: too many arguments to function call, expected 3, have 5
  239 |                 BUS_RELEASE_RESOURCE(device_get_parent(vga),
      |                 ~~~~~~~~~~~~~~~~~~~~
  240 |                     dev_priv->drm.dev->bsddev, SYS_RES_MEMORY, dev_priv->mch_res_rid,
      |                                                                ^~~~~~~~~~~~~~~~~~~~~~
  241 |                     dev_priv->mch_res.bsd_res);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~
./bus_if.h:520:21: note: 'BUS_RELEASE_RESOURCE' declared here
  520 | static __inline int BUS_RELEASE_RESOURCE(device_t _dev, device_t _child,
      |                     ^                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  521 |                                          struct resource *_res)
      |                                          ~~~~~~~~~~~~~~~~~~~~~
[...]
```