### PR TITLE
Remove one more ${.CURDIR}-relative linuxkpi include

### DIFF
--- a/amd/amdkfd/Makefile
+++ b/amd/amdkfd/Makefile
@@ -40,7 +40,6 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
-CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/dummy/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H:H}/include


### PR DESCRIPTION
amdkfd is commented out in amd/Makefile.  Remove the include in case it is ever reconnected to the build.

Fixes: 5b2279ae2a59 ("Remove ${.CURDIR}-relative linuxkpi include")