### PR TITLE
i915: avoid register_fictitious_range on meteorlake

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_color.c
+++ b/drivers/gpu/drm/i915/display/intel_color.c
@@ -1902,6 +1902,11 @@ void intel_color_prepare_commit(struct intel_crtc_state *crtc_state)
 	struct intel_crtc *crtc = to_intel_crtc(crtc_state->uapi.crtc);
 	struct drm_i915_private *i915 = to_i915(crtc->base.dev);
 
+#ifdef __FreeBSD__
+	/* FIXME DSB has issues loading LUTs, disable it for now */
+	return;
+#endif
+
 	if (!crtc_state->hw.active ||
 	    intel_crtc_needs_modeset(crtc_state))
 		return;

--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -243,7 +243,10 @@ static int intelfb_create(struct drm_fb_helper *helper,
 	 * values passed to register_fictitious_range() below are unavailable
 	 * from a generic structure set by both drivers.
 	 */
-	register_fictitious_range(info->fix.smem_start, info->fix.smem_len);
+    printf("intelfb_create: smem_start=%p, smem_len=%p\n");
+	if (info->fix.smem_start != 0) {
+	    //register_fictitious_range(info->fix.smem_start, info->fix.smem_len);
+	}
 #endif
 
 	drm_fb_helper_fill_info(info, &ifbdev->helper, sizes);


### PR DESCRIPTION
On my meteorlake system the info->aperture_base and size fields are not filled out. This seems to have something to do with my GPU having support for device local memory which doesn't get tracked in gmadr.start and mappable_end. This passes zeroes in and makes
register_fictitious_range panic.

This change works around this by simply not registering a fict range at all if the aperture tracking is invalid. This does have the not great side effect of garbling the framebuffer slightly but it prevents the panic and lets desktop usage happen. This workaround can be kept until we figure out what is going wrong with the framebuffer registering.