### PR TITLE
i915: Remove intel_display_trace.c

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_display_trace.c
+++ b/drivers/gpu/drm/i915/display/intel_display_trace.c
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0
-/*
- * Copyright © 2021 Intel Corporation
- */
-
-#ifndef __CHECKER__
-#define CREATE_TRACE_POINTS
-#include "intel_display_trace.h"
-#endif


### PR DESCRIPTION
It carries a GPL SPDX tag, which is probably spurious.  However, we don't compile this anyway so just remove it.

Sponsored by:	The FreeBSD Foundation