### PR TITLE
Remove remaining ${.CURDIR}-relative dummy includes

### DIFF
--- a/drm/Makefile
+++ b/drm/Makefile
@@ -130,7 +130,6 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/bsd/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
-CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include # fallback to dummy
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/dummy/include
 CFLAGS+= -I${SRCDIR}
 CFLAGS+= -I${.CURDIR:H}/include

--- a/dummygfx/Makefile
+++ b/dummygfx/Makefile
@@ -13,7 +13,6 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
-CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include
 CFLAGS+= -I${.CURDIR:H}/include/drm

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -30,7 +30,6 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/bsd/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
-CFLAGS+= -I${.CURDIR:H}/linuxkpi/dummy/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/dummy/include
 
 CFLAGS+= -I${.CURDIR:H}/include


### PR DESCRIPTION
Dummy directories do not exist in the repo so the build was failing with clang 19's stricter include path warnings + Werror. These lines were already removed from a bunch of directories but somehow not from drm/ttm..

Fixes: 5b2279ae2a59 ("Remove ${.CURDIR}-relative linuxkpi include")

---

applies to 6.1-lts exactly as well