### PR TITLE
drm-kmod: Export all symbols

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -1387,3 +1387,5 @@ CWARNFLAGS.vegam_smumgr.c=		-Wno-missing-prototypes
 
 # modules/*
 CWARNFLAGS.freesync.c=			-Wno-unused-but-set-variable
+
+EXPORT_SYMS=	YES

--- a/amd/amdkfd/Makefile
+++ b/amd/amdkfd/Makefile
@@ -71,3 +71,5 @@ CWARNFLAGS.kfd_device_queue_manager.c=	-Wno-format -Wno-strict-prototypes -Wno-i
 CWARNFLAGS.kfd_doorbell.c=	-Wno-format
 CWARNFLAGS.kfd_packet_manager.c=	-Wno-format
 CWARNFLAGS.kfd_queue.c= -Wno-format
+
+EXPORT_SYMS=	YES

--- a/dmabuf/Makefile
+++ b/dmabuf/Makefile
@@ -31,4 +31,6 @@ CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 CWARNFLAGS.dma-buf.c+=	-Wno-pointer-arith
 
+EXPORT_SYMS=	YES
+
 .include <bsd.kmod.mk>

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -162,4 +162,6 @@ CWARNFLAGS+= -Wno-pointer-sign -Wno-format
 
 CWARNFLAGS.drm_ioc32.c+=	-Wno-address-of-packed-member
 
+EXPORT_SYMS=	YES
+
 .include <bsd.kmod.mk>

--- a/dummygfx/Makefile
+++ b/dummygfx/Makefile
@@ -37,6 +37,8 @@ SRCS	+=			\
 	pci_if.h		\
 	vnode_if.h
 
+EXPORT_SYMS=	YES
+
 .include <bsd.kmod.mk>
 
 CWARNFLAGS += -Wno-cast-qual

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -406,3 +406,5 @@ CWARNFLAGS.i9xx_plane.c=	-Wno-unused-but-set-variable
 CWARNFLAGS.g4x_dp.c=		-Wno-shift-count-overflow
 CWARNFLAGS.skl_universal_plane.c=	-Wno-unused-but-set-variable
 CWARNFLAGS.vlv_dsi.c=		-Wno-unused-but-set-variable
+
+EXPORT_SYMS=	YES

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -184,3 +184,5 @@ CWARNFLAGS.trinity_dpm.c=		-Wno-unused-const-variable
 CWARNFLAGS.vce_v1_0.c=			-Wno-missing-prototypes -Wno-cast-qual
 CWARNFLAGS.vce_v2_0.c=			-Wno-missing-prototypes
 CWARNFLAGS.radeon_atpx_handler.c=	-Wno-missing-prototypes -Wno-unused-but-set-variable
+
+EXPORT_SYMS=	YES

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -58,4 +58,6 @@ CWARNFLAGS+=-Wno-cast-qual
 CWARNFLAGS+= -Wno-pointer-arith -Wno-pointer-sign -Wno-format
 CWARNFLAGS+= -Wno-expansion-to-defined
 
+EXPORT_SYMS=	YES
+
 .include <bsd.kmod.mk>


### PR DESCRIPTION
We currently rely on the kernel linker's misbehaviour of exporting local symbols from modules, controlled by the debug.link_elf_obj_leak_locals and debug.link_elf_leak_locals sysctls.

Explicitly export all symbols (making the current behaviour explicit) as a step to turning off the sysctls by default.  A future change should have us export only the desired symbols.

Sponsored by:	The FreeBSD Foundation