### PR TITLE
i915: Use iterators to traverse resident VM object pages

### DIFF
--- a/drivers/gpu/drm/i915/gem/i915_gem_mman.c
+++ b/drivers/gpu/drm/i915/gem/i915_gem_mman.c
@@ -34,6 +34,7 @@
 #include <vm/vm_object.h>
 #include <vm/vm_pager.h>
 #include <vm/vm_param.h>
+#include <vm/vm_radix.h>
 #endif
 
 #ifdef __linux__ /* Mute unused function warning. */
@@ -168,9 +169,16 @@ i915_gem_mmap_ioctl(struct drm_device *dev, void *data,
 	if ((rv == KERN_SUCCESS) && (args->flags & I915_MMAP_WC)) {
 		VM_OBJECT_WLOCK(vmobj);
 		if (vm_object_set_memattr(vmobj, VM_MEMATTR_WRITE_COMBINING) != KERN_SUCCESS) {
-			for (vm_page_t page = vm_page_find_least(vmobj, 0); page != NULL; page = vm_page_next(page)) {
+#if __FreeBSD_version >= 1500038
+			struct pctrie_iter pages;
+			vm_page_t page;
+
+			vm_page_iter_init(&pages, vmobj);
+			VM_RADIX_FORALL(page, &pages)
+#else
+			for (vm_page_t page = vm_page_find_least(vmobj, 0); page != NULL; page = vm_page_next(page))
+#endif
 				pmap_page_set_memattr(page, VM_MEMATTR_WRITE_COMBINING);
-			}
 		}
 		VM_OBJECT_WUNLOCK(vmobj);
 	}


### PR DESCRIPTION
vm_page_next() is removed in 15.0.

This affects most of the DRM branches. Should I submit PRs for all of them?