### PR TITLE
dma-buf: Fix the type of the return variable in dma_fence_wait_timeout()

### DIFF
--- a/drivers/dma-buf/dma-fence.c
+++ b/drivers/dma-buf/dma-fence.c
@@ -188,7 +188,7 @@ dma_fence_timestamp(struct dma_fence *fence)
 signed long
 dma_fence_wait_timeout(struct dma_fence *fence, bool intr, signed long timeout)
 {
-	int rv;
+	signed long rv;
 
 	if (fence == NULL)
 		return (-EINVAL);


### PR DESCRIPTION
After jiffies was widened, MAX_SCHEDULE_TIMEOUT gets truncated to 0xffffffff, which is sign-extended to a negative value.