### PR TITLE
drm: check if fpriv is the current master of the device

### DIFF
--- a/drivers/gpu/drm/drm_auth.c
+++ b/drivers/gpu/drm/drm_auth.c
@@ -68,7 +68,7 @@ static bool drm_is_current_master_locked(struct drm_file *fpriv)
 #ifdef __linux__
 	return fpriv->is_master && drm_lease_owner(fpriv->master) == fpriv->minor->dev->master;
 #elif defined(__FreeBSD__)
-	return fpriv->is_master;
+	return fpriv->is_master && fpriv->master == fpriv->minor->dev->master;
 #endif
 }
 


### PR DESCRIPTION
Fix incomplete check for the current master of the device, which breaks modesetting_drv when switching to VT and back to X.

This should be also cherry-picked to older drm code (drm-61, drm-515 and drm-510)

Fixes #175