### PR TITLE
Cleanup LinuxKPI PCI vs. native [master]

### DIFF
--- a/drivers/gpu/drm/drm_internal.h
+++ b/drivers/gpu/drm/drm_internal.h
@@ -56,10 +56,6 @@ void drm_lastclose(struct drm_device *dev);
 #ifdef CONFIG_PCI
 
 /* drm_pci.c */
-#ifdef __FreeBSD__
-int drm_getpciinfo(struct drm_device *dev, void *data,
-		     struct drm_file *file_priv);
-#endif
 int drm_pci_set_busid(struct drm_device *dev, struct drm_master *master);
 
 #else

--- a/drivers/gpu/drm/drm_pci.c
+++ b/drivers/gpu/drm/drm_pci.c
@@ -47,33 +47,22 @@ static int drm_get_pci_domain(struct drm_device *dev)
 		return 0;
 #endif /* __alpha__ */
 
-#ifdef __FreeBSD__
-	return pci_get_domain(dev->dev->bsddev);
-#else
 	return pci_domain_nr(to_pci_dev(dev->dev)->bus);
-#endif
 }
 
 int drm_pci_set_busid(struct drm_device *dev, struct drm_master *master)
 {
 	struct pci_dev *pdev = to_pci_dev(dev->dev);
 
-#ifdef __FreeBSD__
-	master->unique = kasprintf(GFP_KERNEL, "pci:%04x:%02x:%02x.%d",
-					drm_get_pci_domain(dev),
-					pci_get_bus(dev->dev->bsddev),
-					pci_get_slot(dev->dev->bsddev),
-					PCI_FUNC(pdev->devfn));
-#else
 	master->unique = kasprintf(GFP_KERNEL, "pci:%04x:%02x:%02x.%d",
 					drm_get_pci_domain(dev),
 					pdev->bus->number,
 					PCI_SLOT(pdev->devfn),
 					PCI_FUNC(pdev->devfn));
-#endif
 	if (!master->unique)
 		return -ENOMEM;
 
 	master->unique_len = strlen(master->unique);
 	return 0;
 }
+

--- a/drivers/gpu/drm/drm_sysctl_freebsd.c
+++ b/drivers/gpu/drm/drm_sysctl_freebsd.c
@@ -170,14 +170,13 @@ drm_add_busid_modesetting(struct drm_device *dev, struct sysctl_ctx_list *ctx,
     struct sysctl_oid *top)
 {
 	struct sysctl_oid *oid;
-	device_t bsddev;
 	int domain, bus, slot, func;
+	struct pci_dev *pdev = to_pci_dev(dev->dev);
 
-	bsddev = dev->dev->bsddev;
-	domain = pci_get_domain(bsddev);
-	bus    = pci_get_bus(bsddev);
-	slot   = pci_get_slot(bsddev);
-	func   = pci_get_function(bsddev);
+	domain = pci_domain_nr(pdev->bus);
+	bus    = pdev->bus->number;
+	slot   = PCI_SLOT(pdev->devfn);
+	func   = PCI_FUNC(pdev->devfn);
 
 	snprintf(dev->busid_str, sizeof(dev->busid_str),
 	    "pci:%04x:%02x:%02x.%d", domain, bus, slot, func);


### PR DESCRIPTION
This change does not only cleanup the code and cleanup FreeBSD native bits but also avoids conflicts with upcoming LinuxKPI PCI changes