### PR TITLE
Uncomment the use of `hex_dump_to_buffer()` in i915

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_engine_cs.c
+++ b/drivers/gpu/drm/i915/gt/intel_engine_cs.c
@@ -2061,7 +2061,7 @@ static void linux_hexdump(struct drm_printer *m, const void *buf, size_t len)
 			continue;
 		}
 
-#ifdef __linux__
+#if __FreeBSD_version >= 1600008
 		WARN_ON_ONCE(hex_dump_to_buffer(buf + pos, len - pos,
 						rowsize, sizeof(u32),
 						line, sizeof(line),


### PR DESCRIPTION
It is implemented in FreeBSD as of 1600008.

Sponsored by:	The FreeBSD Foundation