### PR TITLE
drm/i915: Additional local_irq_en/disable conversions

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_crtc.c
+++ b/drivers/gpu/drm/i915/display/intel_crtc.c
@@ -514,6 +514,8 @@ void intel_pipe_update_start(struct intel_atomic_state *state,
 
 #ifdef __linux__
 	local_irq_disable();
+#elif defined(__FreeBSD__)
+	preempt_disable();
 #endif
 
 	crtc->debug.min_vbl = evade.min;
@@ -535,7 +537,7 @@ irq_disable:
 #ifdef __linux__
 	local_irq_disable();
 #elif defined(__FreeBSD__)
-	return;
+	preempt_disable();
 #endif
 }
 
@@ -640,6 +642,8 @@ void intel_pipe_update_end(struct intel_atomic_state *state,
 
 #ifdef __linux__
 	local_irq_enable();
+#elif defined(__FreeBSD__)
+	preempt_enable();
 #endif
 
 	if (intel_vgpu_active(dev_priv))

--- a/drivers/gpu/drm/i915/display/intel_vblank.c
+++ b/drivers/gpu/drm/i915/display/intel_vblank.c
@@ -684,12 +684,16 @@ int intel_vblank_evade(struct intel_vblank_evade_ctx *evade)
 
 #ifdef __linux__
 		local_irq_enable();
+#elif defined(__FreeBSD__)
+		preempt_enable();
 #endif
 
 		timeout = schedule_timeout(timeout);
 
 #ifdef __linux__
 		local_irq_disable();
+#elif defined(__FreeBSD__)
+		preempt_disable();
 #endif
 	}
 


### PR DESCRIPTION
Use preempt_en/disable where upstream calls local_irq_en/disable in intel_pipe_update_start, intel_pipe_update_end, and intel_vblank_evade as already done elsewhere in drm/i915.  There are additional cases that need investigation but this is now usable on my 11th gen Intel laptop.

Closes: #375