### PR TITLE
drm/amd/display: Avoid useless ~14kB contiguous allocations in hot paths

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/basics/dce_calcs.c
+++ b/drivers/gpu/drm/amd/display/dc/basics/dce_calcs.c
@@ -3045,8 +3045,13 @@ bool bw_calcs(struct dc_context *ctx,
 	int pipe_count,
 	struct dce_bw_output *calcs_output)
 {
+#ifdef __FreeBSD__
+	struct bw_calcs_data *data = kvzalloc(sizeof(struct bw_calcs_data),
+					      GFP_KERNEL);
+#else
 	struct bw_calcs_data *data = kzalloc(sizeof(struct bw_calcs_data),
 					     GFP_KERNEL);
+#endif
 	if (!data)
 		return false;
 


### PR DESCRIPTION
'struct bw_calcs_data' is just a temporary big structure that does not need physically contiguous memory, so just do a regular allocation.

This fixes noticeable slowdowns on FreeBSD by removing a contiguous allocation in hot paths.

Sponsored by:   The FreeBSD Foundation