### PR TITLE
DRM 5.15: Avoid useless ~14kB contiguous allocations

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/dml/calcs/dce_calcs.c
+++ b/drivers/gpu/drm/amd/display/dc/dml/calcs/dce_calcs.c
@@ -3047,8 +3047,8 @@ bool bw_calcs(struct dc_context *ctx,
 	int pipe_count,
 	struct dce_bw_output *calcs_output)
 {
-	struct bw_calcs_data *data = kzalloc(sizeof(struct bw_calcs_data),
-					     GFP_KERNEL);
+	struct bw_calcs_data *data = kvzalloc(sizeof(struct bw_calcs_data),
+					      GFP_KERNEL);
 	if (!data)
 		return false;
 


### PR DESCRIPTION
See pull request #377 for the rationale.  This is the backport for DRM 5.15.