### PR TITLE
drm/i915: Disable preemption when acquiring spin_lock in `intel_vblank`

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_crtc.c
+++ b/drivers/gpu/drm/i915/display/intel_crtc.c
@@ -514,8 +514,6 @@ void intel_pipe_update_start(struct intel_atomic_state *state,
 
 #ifdef __linux__
 	local_irq_disable();
-#elif defined(__FreeBSD__)
-	preempt_disable();
 #endif
 
 	crtc->debug.min_vbl = evade.min;
@@ -537,7 +535,7 @@ irq_disable:
 #ifdef __linux__
 	local_irq_disable();
 #elif defined(__FreeBSD__)
-	preempt_disable();
+	return;
 #endif
 }
 
@@ -642,8 +640,6 @@ void intel_pipe_update_end(struct intel_atomic_state *state,
 
 #ifdef __linux__
 	local_irq_enable();
-#elif defined(__FreeBSD__)
-	preempt_enable();
 #endif
 
 	if (intel_vgpu_active(dev_priv))

--- a/drivers/gpu/drm/i915/display/intel_cursor.c
+++ b/drivers/gpu/drm/i915/display/intel_cursor.c
@@ -777,8 +777,6 @@ intel_legacy_cursor_update(struct drm_plane *_plane,
 
 #ifdef __linux__
 		local_irq_disable();
-#elif defined(__FreeBSD__)
-		preempt_disable();
 #endif
 
 		intel_vblank_evade(&evade);
@@ -787,8 +785,6 @@ intel_legacy_cursor_update(struct drm_plane *_plane,
 	} else {
 #ifdef __linux__
 		local_irq_disable();
-#elif defined(__FreeBSD__)
-		preempt_disable();
 #endif
 	}
 
@@ -801,8 +797,6 @@ intel_legacy_cursor_update(struct drm_plane *_plane,
 
 #ifdef __linux__
 	local_irq_enable();
-#elif defined(__FreeBSD__)
-	preempt_enable();
 #endif
 
 	intel_psr_unlock(crtc_state);

--- a/drivers/gpu/drm/i915/display/intel_vblank.c
+++ b/drivers/gpu/drm/i915/display/intel_vblank.c
@@ -690,16 +690,12 @@ int intel_vblank_evade(struct intel_vblank_evade_ctx *evade)
 
 #ifdef __linux__
 		local_irq_enable();
-#elif defined(__FreeBSD__)
-		preempt_enable();
 #endif
 
 		timeout = schedule_timeout(timeout);
 
 #ifdef __linux__
 		local_irq_disable();
-#elif defined(__FreeBSD__)
-		preempt_disable();
 #endif
 	}
 


### PR DESCRIPTION
This fixes a "mi_switch: switch in a critical section" panic I hit frequently with the i915 driver.

In fact, on Linux, spin_locks imply that preemption is disabled until it is unlocked. We can't do that on FreeBSD, because spin_lock-protected code may call malloc(9) which, on FreeBSD, can't happen in a critical section, even if we set the `M_NOWAIT` flag.

That's why we introduce a special case here: we can't simply disable preemption in `spin_lock()`.

This is a follow-up to #376 and should fix #375.