### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/resource/dcn35/dcn35_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/resource/dcn35/dcn35_resource.c
@@ -1714,6 +1714,7 @@ static struct clock_source *dcn35_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/resource/dcn351/dcn351_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/resource/dcn351/dcn351_resource.c
@@ -1694,6 +1694,7 @@ static struct clock_source *dcn35_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }


### PR DESCRIPTION
### Summary

Our tool detected a potential memory leak vulnerability in `drivers/gpu/drm/amd/display/dc/resource/dcn35/dcn35_resource.c`, `drivers/gpu/drm/amd/display/dc/resource/dcn351/dcn351_resource.c` which was cloned from https://github.com/torvalds/linux/commit/055e547478a11a6360c7ce05e2afc3e366968a12 but did not receive the security patch. The original issue was reported and fixed under [CVE-2019-19083](https://nvd.nist.gov/vuln/detail/CVE-2019-19083).

### Proposed Fix

Apply the same patch as the one in torvalds/linux to eliminate the vulnerability.

### References

https://nvd.nist.gov/vuln/detail/CVE-2019-19083
https://github.com/torvalds/linux/commit/055e547478a11a6360c7ce05e2afc3e366968a12