### PR TITLE
drm-kmod: LinuxKPI: use linux-native struct page

### DIFF
--- a/drivers/gpu/drm/i915/i915_gpu_error.h
+++ b/drivers/gpu/drm/i915/i915_gpu_error.h
@@ -43,7 +43,7 @@ struct i915_vma_coredump {
 	u32 gtt_page_sizes;
 
 	int unused;
-#ifdef __linux__
+#if defined(__linux__) || defined(PAGE_IS_LKPI_PAGE)
 	struct list_head page_list;
 #elif defined(__FreeBSD__)
 	struct pglist page_list;

--- a/drivers/gpu/drm/ttm/ttm_bo_vm.c
+++ b/drivers/gpu/drm/ttm/ttm_bo_vm.c
@@ -242,7 +242,7 @@ vm_fault_t ttm_bo_vm_fault_reserved(struct vm_fault *vmf,
 	 * Speculatively prefault a number of pages. Only error on
 	 * first page.
 	 */
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
 	VM_OBJECT_WLOCK(vma->vm_obj);
 #endif
 	for (i = 0; i < num_prefault; ++i) {
@@ -251,20 +251,24 @@ vm_fault_t ttm_bo_vm_fault_reserved(struct vm_fault *vmf,
 		} else {
 			page = ttm->pages[page_offset];
 			if (unlikely(!page && i == 0)) {
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
 				VM_OBJECT_WUNLOCK(vma->vm_obj);
 #endif
 				return VM_FAULT_OOM;
 			} else if (unlikely(!page)) {
 				break;
 			}
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
+#if defined(PAGE_IS_LKPI_PAGE)
+			page->vm_page->oflags &= ~VPO_UNMANAGED;
+#else
 			page->oflags &= ~VPO_UNMANAGED;
+#endif
 #endif
 			pfn = page_to_pfn(page);
 		}
 
-#ifdef __linux__
+#if defined(__linux__)
 		/*
 		 * Note that the value of @prot at this point may differ from
 		 * the value of @vma->vm_page_prot in the caching- and
@@ -281,7 +285,7 @@ vm_fault_t ttm_bo_vm_fault_reserved(struct vm_fault *vmf,
 		/* Never error on prefaulted PTEs */
 		if (unlikely((ret & VM_FAULT_ERROR))) {
 			if (i == 0) {
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
 				VM_OBJECT_WUNLOCK(vma->vm_obj);
 #endif
 				return VM_FAULT_NOPAGE;
@@ -293,7 +297,7 @@ vm_fault_t ttm_bo_vm_fault_reserved(struct vm_fault *vmf,
 		if (unlikely(++page_offset >= page_last))
 			break;
 	}
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
 	VM_OBJECT_WUNLOCK(vma->vm_obj);
 #endif
 	return ret;

--- a/drivers/gpu/drm/ttm/ttm_tt.c
+++ b/drivers/gpu/drm/ttm/ttm_tt.c
@@ -114,7 +114,7 @@ EXPORT_SYMBOL_FOR_TESTS_ONLY(ttm_tt_create);
  */
 static int ttm_tt_alloc_page_directory(struct ttm_tt *ttm)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(PAGE_IS_LKPI_PAGE)
 	ttm->pages = kvcalloc(ttm->num_pages, sizeof(void*), GFP_KERNEL);
 #elif defined(__FreeBSD__)
 	ttm->pages = kvcalloc(ttm->num_pages,
@@ -123,7 +123,7 @@ static int ttm_tt_alloc_page_directory(struct ttm_tt *ttm)
 #endif
 	if (!ttm->pages)
 		return -ENOMEM;
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && !defined(PAGE_IS_LKPI_PAGE)
 	ttm->orders = (void *)(ttm->pages + ttm->num_pages);
 #endif
 
@@ -132,7 +132,7 @@ static int ttm_tt_alloc_page_directory(struct ttm_tt *ttm)
 
 static int ttm_dma_tt_alloc_page_directory(struct ttm_tt *ttm)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(PAGE_IS_LKPI_PAGE)
 	ttm->pages = kvcalloc(ttm->num_pages, sizeof(*ttm->pages) +
 			      sizeof(*ttm->dma_address), GFP_KERNEL);
 #elif defined(__FreeBSD__)
@@ -144,7 +144,7 @@ static int ttm_dma_tt_alloc_page_directory(struct ttm_tt *ttm)
 		return -ENOMEM;
 
 	ttm->dma_address = (void *)(ttm->pages + ttm->num_pages);
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && !defined(PAGE_IS_LKPI_PAGE)
 	ttm->orders = (void *)(ttm->dma_address + ttm->num_pages);
 #endif
 	return 0;

--- a/include/drm/ttm/ttm_pool.h
+++ b/include/drm/ttm/ttm_pool.h
@@ -54,7 +54,7 @@ struct ttm_pool_type {
 	struct list_head shrinker_list;
 
 	spinlock_t lock;
-#ifdef __linux__
+#if defined(__linux__) || defined(PAGE_IS_LKPI_PAGE)
 	struct list_head pages;
 #elif defined(__FreeBSD__)
 	struct pglist pages;

--- a/include/drm/ttm/ttm_tt.h
+++ b/include/drm/ttm/ttm_tt.h
@@ -46,7 +46,7 @@ struct ttm_operation_ctx;
 struct ttm_tt {
 	/** @pages: Array of pages backing the data. */
 	struct page **pages;
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && !defined(PAGE_IS_LKPI_PAGE)
 	/* On Linux, `struct page` has a private field. It is used by
 	 * `ttm_pool` to store private data. FreeBSD's `struct vm_page` does
 	 * not have that, so we use an extra field in `struct ttm_tt` */


### PR DESCRIPTION
In order to support page_pools and further changes there is a plan to migrate 'struct page' away from vm_page_t to Linux-native struct page. The change introduces a conditional (PAGE_IS_LKPI_PAGE), which is also used for the migration in LinuxKPI, to allow for a smooth transition. Adding the conditionals here upfront serves two goals: (i) prepare drm-kmod for the LinuxKPI changes to come, so that drm-kmod will not break, and (ii) allow people trying out PAGE_IS_LKPI_PAGE for page_pools/the mt76 wireless driver to also be able to use drm-kmod. In the long-term once LinuxKPI transitioned, this will also help to redice FreeBSD-specific code in drm-kmod.

Sponsored by:	The FreeBSD Foundation

This chnage so far was only compile-time tested as my amdgpu does not work otherwise yet again.

@OlCe2 @emaste