### PR TITLE
drm/i915 (FreeBSD): Don't use DSB to load LUTs on FreeBSD

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_color.c
+++ b/drivers/gpu/drm/i915/display/intel_color.c
@@ -1902,6 +1902,14 @@ void intel_color_prepare_commit(struct intel_crtc_state *crtc_state)
 	struct intel_crtc *crtc = to_intel_crtc(crtc_state->uapi.crtc);
 	struct drm_i915_private *i915 = to_i915(crtc->base.dev);
 
+#ifdef __FreeBSD__
+	/*
+	 * BSDFIXME: This causes color corruption.
+	 * See https://github.com/freebsd/drm-kmod/pull/332#issuecomment-2585288390
+	 */
+	return;
+#endif
+
 	if (!crtc_state->hw.active ||
 	    intel_crtc_needs_modeset(crtc_state))
 		return;


### PR DESCRIPTION
This was fixed on Linux but it still causes color corruption on FreeBSD. We must have one or more remaining issues in the compat code in the driver or in linuxkpi.