### PR TITLE
dma-buf: Zero out stat struct in dma_buf_stat

### DIFF
--- a/drivers/dma-buf/dma-buf.c
+++ b/drivers/dma-buf/dma-buf.c
@@ -136,7 +136,7 @@ dma_buf_stat(struct file *fp, struct stat *sb,
 {
 
 	/* XXX need to define flags for st_mode */
-	bzero(sb, sizeof(*sb));
+	memset(sb, 0, sizeof(*sb));
 	return (0);
 }
 


### PR DESCRIPTION
`kern_fstat`, which ends up calling `dma_buf_stat` does not zero this for us (see [D54556](https://reviews.freebsd.org/D54556)). This causes issues because obviously we're leaking kernel stack to the userspace, but also because the `st_ino` field contains garbage.

The wlroots Vulkan renderer relies on checking inos of all the planes of a DMA-BUF to know if it is disjointed or not, (see [`render/vulkan/texture.c:is_dmabuf_disjoint`](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/render/vulkan/texture.c?ref_type=heads#L478)). This caused very transient issues, where sometimes these inos happened to not match up.

I don't yet know how Linux sets the inos on DMA-BUF planes, but in fine we will want to emulate that behaviour. This fixes things for now though as now all inos are 0 so they will never be seen as disjointed.