### PR TITLE
dma-buf: Add necessary flags for ioctls on DMA-BUF files

### DIFF
--- a/drivers/dma-buf/dma-buf.c
+++ b/drivers/dma-buf/dma-buf.c
@@ -465,7 +465,7 @@ dma_buf_export(const struct dma_buf_export_info *exp_info)
 	if ((err = falloc_noinstall(curthread, &fp)) != 0)
 		goto err;
 
-	finit(fp, 0, DTYPE_DMABUF, db, &dma_buf_fileops);
+	finit(fp, FREAD | FWRITE, DTYPE_DMABUF, db, &dma_buf_fileops);
 
 	db->linux_file = fp;
 	mutex_init(&db->lock);


### PR DESCRIPTION
`struct file`s are checked for the `FREAD` or `FWRITE` flags when calling `ioctl()` on them. DMA-BUFs didn't have these set, without which `DMA_BUF_IOCTL_SYNC` cannot work.

I ran into this when working on implementing `DMA_BUF_IOCTL_EXPORT_SYNC_FILE` and `DMA_BUF_IOCTL_IMPORT_SYNC_FILE`, but I couldn't find any software on FreeBSD which actually uses the `DMA_BUF_IOCTL_SYNC` ioctl already which I could use to test this. Does anyone know of any?