### PR TITLE
dma-buf: Implement `DMA_BUF_IOCTL_{EXPORT,IMPORT}_SYNC_FILE`

### DIFF
--- a/linuxkpi/bsd/include/uapi/linux/dma-buf.h
+++ b/linuxkpi/bsd/include/uapi/linux/dma-buf.h
@@ -42,4 +42,18 @@ struct dma_buf_sync {
 
 #define	DMA_BUF_IOCTL_SYNC		_IOW('b', 0, struct dma_buf_sync)
 
+struct dma_buf_export_sync_file {
+	__u32	flags;
+	__s32	fd;
+};
+
+#define	DMA_BUF_IOCTL_EXPORT_SYNC_FILE	_IOWR('b', 1, struct dma_buf_export_sync_file)
+
+struct dma_buf_import_sync_file {
+	__u32	flags;
+	__s32	fd;
+};
+
+#define	DMA_BUF_IOCTL_IMPORT_SYNC_FILE	_IOW('b', 2, struct dma_buf_import_sync_file)
+
 #endif	/* _BSD_LKPI_UAPI_LINUX_DMA_BUF_H_ */


### PR DESCRIPTION
Still not exactly the same behaviour as the Linux code, but I'm running this on Sway with wlroots' Vulkan renderer (which needs these for implicit sync interoperability) and it seems to work.

Maybe someone with a bit more LinuxKPI experience can tell me if there's a less hacky way to do this part:

```c
/* We need to set these for linux_fget to work in sync_file_fdget. */
sync_file->linux_file->_file->f_ops = &linuxfileops;
sync_file->linux_file->_file->f_data = sync_file->linux_file;
```

This depends on #404.