### PR TITLE
drm/amd/amdgpu: Fix panic when load fail

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
@@ -4557,7 +4557,8 @@ void amdgpu_device_fini_hw(struct amdgpu_device *adev)
 	amdgpu_ras_pre_fini(adev);
 
 #ifdef __FreeBSD__
-	unregister_fictitious_range(adev->gmc.aper_base, adev->gmc.aper_size);
+	if (adev->gmc.aper_size > 0)
+		unregister_fictitious_range(adev->gmc.aper_base, adev->gmc.aper_size);
 #endif
 
 	amdgpu_ttm_set_buffer_funcs_status(adev, false);


### PR DESCRIPTION
When the amdgpu driver fails to initialize early (e.g., due to missing or mismatched firmware), amdgpu will panic in amdgpu_device_fini_hw() Because at this point, adev->gmc.aper_base and aper_size remain 0. it triggering KASSERT in vm_phys_fictitious_unreg_range

Fixes: 99bc6076ee ("drm: Remove drm_mode_config::fb_base")
Related to #409 