### PR TITLE
Don't unregister fictitious range if not registered

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
@@ -4343,7 +4343,7 @@ fence_driver_init:
 	 * values passed to register_fictitious_range() below are unavailable
 	 * from a generic structure set by both drivers.
 	 */
-	register_fictitious_range(adev->gmc.aper_base, adev->gmc.aper_size);
+	register_fictitious_range(ddev, adev->gmc.aper_base, adev->gmc.aper_size);
 #endif
 
 	amdgpu_fence_driver_hw_init(adev);
@@ -4557,7 +4557,7 @@ void amdgpu_device_fini_hw(struct amdgpu_device *adev)
 	amdgpu_ras_pre_fini(adev);
 
 #ifdef __FreeBSD__
-	unregister_fictitious_range(adev->gmc.aper_base, adev->gmc.aper_size);
+	unregister_fictitious_range(adev_to_drm(adev), adev->gmc.aper_base, adev->gmc.aper_size);
 #endif
 
 	amdgpu_ttm_set_buffer_funcs_status(adev, false);

--- a/drivers/gpu/drm/drm_os_freebsd.c
+++ b/drivers/gpu/drm/drm_os_freebsd.c
@@ -2,6 +2,7 @@
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
+#include <drm/drm_device.h>
 #include <drm/drm_file.h>
 #include <drm/drm_ioctl.h>
 #include <drm/drm_print.h>
@@ -78,7 +79,7 @@ sysctl_pci_id(SYSCTL_HANDLER_ARGS)
 }
 
 int
-register_fictitious_range(vm_paddr_t base, size_t size)
+register_fictitious_range(struct drm_device *ddev, vm_paddr_t base, size_t size)
 {
 	int ret;
 	struct apertures_struct *ap;
@@ -101,14 +102,18 @@ register_fictitious_range(vm_paddr_t base, size_t size)
 	    );
 	MPASS(ret == 0);
 
+	ddev->fictitious_range_registered = true;
+
 	return (ret);
 }
 
 void
-unregister_fictitious_range(vm_paddr_t base, size_t size)
+unregister_fictitious_range(struct drm_device *ddev, vm_paddr_t base, size_t size)
 {
-	vm_phys_fictitious_unreg_range(base, base + size);
-	vt_unfreeze_main_vd();
+	if (ddev->fictitious_range_registered) {
+		vm_phys_fictitious_unreg_range(base, base + size);
+		vt_unfreeze_main_vd();
+	}
 }
 
 /* Framebuffer related code */

--- a/drivers/gpu/drm/drm_os_freebsd.h
+++ b/drivers/gpu/drm/drm_os_freebsd.h
@@ -38,8 +38,9 @@ void cancel_reset_debug_log(void);
 void vt_freeze_main_vd(struct apertures_struct *a);
 void vt_unfreeze_main_vd(void);
 
-int register_fictitious_range(vm_paddr_t start, vm_paddr_t end);
-void unregister_fictitious_range(vm_paddr_t start, vm_paddr_t end);
+struct drm_device;
+int register_fictitious_range(struct drm_device *ddev, vm_paddr_t start, vm_paddr_t end);
+void unregister_fictitious_range(struct drm_device *ddev, vm_paddr_t start, vm_paddr_t end);
 
 #if 0
 struct linux_fb_info;

--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -141,6 +141,7 @@ static void intel_fbdev_fb_destroy(struct fb_info *info)
 
 #ifdef __FreeBSD__
 	unregister_fictitious_range(
+		fb_helper->dev,
 		ifbdev->helper.info->fix.smem_start,
 		ifbdev->helper.info->fix.smem_len);
 #endif
@@ -271,7 +272,7 @@ static int intelfb_create(struct drm_fb_helper *helper,
 	 * values passed to register_fictitious_range() below are unavailable
 	 * from a generic structure set by both drivers.
 	 */
-	register_fictitious_range(info->fix.smem_start, info->fix.smem_len);
+	register_fictitious_range(dev, info->fix.smem_start, info->fix.smem_len);
 #endif
 
 	drm_fb_helper_fill_info(info, &ifbdev->helper, sizes);

--- a/drivers/gpu/drm/radeon/radeon_fbdev.c
+++ b/drivers/gpu/drm/radeon/radeon_fbdev.c
@@ -179,7 +179,7 @@ static void radeon_fbdev_fb_destroy(struct fb_info *info)
 
 #ifdef __FreeBSD__
 	struct radeon_device *rdev = fb_helper->dev->dev_private;
-	unregister_fictitious_range(rdev->mc.aper_base, rdev->mc.aper_size);
+	unregister_fictitious_range(fb_helper->dev, rdev->mc.aper_base, rdev->mc.aper_size);
 #endif
 
 	drm_fb_helper_fini(fb_helper);
@@ -288,7 +288,7 @@ static int radeon_fbdev_fb_helper_fb_probe(struct drm_fb_helper *fb_helper,
 	 * values passed to register_fictitious_range() below are unavailable
 	 * from a generic structure set by both drivers.
 	 */
-	register_fictitious_range(rdev->mc.aper_base, rdev->mc.aper_size);
+	register_fictitious_range(fb_helper->dev, rdev->mc.aper_base, rdev->mc.aper_size);
 #endif
 
 	/* Use default scratch pixmap (info->pixmap.flags = FB_PIXMAP_SYSTEM) */

--- a/include/drm/drm_device.h
+++ b/include/drm/drm_device.h
@@ -310,6 +310,7 @@ struct drm_device {
 	void *sysctl_private;
 	char busid_str[128];
 	int modesetting;
+	bool fictitious_range_registered;
 /* FIXME: Should be defined in linux/mmzone.h and include linux/mmzone.h in the
  * correct headers, such as gfp.h. */
 #define	MAX_ORDER 11


### PR DESCRIPTION
When the DRM driver fails to initialise a device, it will undo what it did (it "finishes" the device).

On FreeBSD, finishing a device includes the unregistration of the fictitious range. However, the range was unregistered regardless if it was registered in the first place or not. In other words, no matter if the device was successfully initialised or not, we unregistered the range.

For instance with the amdgpu DRM driver, this led to different panics depending on the kernel configuration (and the assertions that come with it):

```
panic: Start of segment isn't less than end (start: 0 end: 0)
```
```
panic: page fault
```

... all of them originating from the `vm_phys_fictitious_unreg_range()` function.

This patch adds a FreeBSD-specific boolean in `struct drm_device` to track if the fictitious range was registered or not. We use it at the time of unregistration to possibly skip that step.

Closes: #409