### PR TITLE
drm/i915: Get meteorlake graphics working

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_hdcp.c
+++ b/drivers/gpu/drm/i915/display/intel_hdcp.c
@@ -2279,6 +2279,15 @@ static int initialize_hdcp_port_data(struct intel_connector *connector,
 
 static bool is_hdcp2_supported(struct drm_i915_private *i915)
 {
+#ifdef __FreeBSD__
+	/*
+	 * HDCP is not supported on meteorlake because it requires
+	 * GSC which depends on the MEI driver, which we do not have.
+	 */
+	if (!IS_ENABLED(CONFIG_INTEL_MEI_HDCP))
+		return false;
+#endif
+
 	if (intel_hdcp_gsc_cs_required(i915))
 		return true;
 

--- a/drivers/gpu/drm/i915/gt/intel_ggtt.c
+++ b/drivers/gpu/drm/i915/gt/intel_ggtt.c
@@ -1229,7 +1229,22 @@ static int gen8_gmch_probe(struct i915_ggtt *ggtt)
 	unsigned int size;
 	u16 snb_gmch_ctl;
 
+#ifdef __linux__
 	if (!HAS_LMEM(i915) && !HAS_LMEMBAR_SMEM_STOLEN(i915)) {
+#elif defined(__FreeBSD__)
+	/*
+	 * We need to initialize GMADR on freebsd in order to use shmem
+	 * framebuffers. We are falling back to shmem framebuffers on freebsd
+	 * because the Wa_22018444074 mtl hardware workaround disabled using stolen
+	 * memory on mtl. Unlike on linux, when this happens we end up passing an
+	 * invalid phys address to register_fictitious_range which causes a panic.
+	 * Because GMADR is not valid we end up with a value such as 0x2000 instead
+	 * of a valid pointer.
+	 * MTL has LMEMBAR for stolen but still needs GMADR for shmem objects.
+	 */
+	if ((!HAS_LMEM(i915) && !HAS_LMEMBAR_SMEM_STOLEN(i915))
+			|| HAS_LMEMBAR_SMEM_STOLEN(i915)) {
+#endif
 		if (!i915_pci_resource_valid(pdev, GEN4_GMADR_BAR))
 			return -ENXIO;
 

--- a/drivers/gpu/drm/i915/gt/intel_gt.c
+++ b/drivers/gpu/drm/i915/gt/intel_gt.c
@@ -961,6 +961,20 @@ int intel_gt_probe_all(struct drm_i915_private *i915)
 			break;
 
 		case GT_MEDIA:
+#ifdef __FreeBSD__
+			/*
+			 * Skip standalone media GT on Meteor Lake.
+			 * FreeBSD lacks MEI driver support needed for GSC proxy,
+			 * which causes GuC authentication to fail on GT1.
+			 */
+			if (!IS_ENABLED(CONFIG_INTEL_MEI_HDCP)) {
+				drm_info(&i915->drm,
+						"Skipping GT1 (Standalone Media GT) - MEI driver not available on FreeBSD\n");
+				ret = 0;
+				continue;
+			}
+#endif
+
 			ret = intel_sa_mediagt_setup(gt, phys_addr + gtdef->mapping_base,
 						     gtdef->gsi_offset);
 			break;


### PR DESCRIPTION
These are a few fixes which get GuC based graphics working on meteorlake (and hopefully newer). This finally makes my dell precision 5690 laptop with Arc graphics usable. Details on each fix are in the commit descriptions. Tested with sway, plasma6 (x11), and xfce4.

You'll also want ~[D55525](https://reviews.freebsd.org/D55525)~ [D55536](https://reviews.freebsd.org/D55536) in order to prevent panics once we bump the GTT version to 4, which was an existing problem that mtl runs into. On mtl we must have GTT version 4 or else it falls back to the legacy mapping path which mtl does not support.

This should fix #373

GuC is disabled by default for now, add `hw.i915kms.enable_guc="2"` to `loader.conf` to enable it.