### PR TITLE
drm/i915: Swap spin_lock() and preempt_disable() [FreeBSD]

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_vblank.c
+++ b/drivers/gpu/drm/i915/display/intel_vblank.c
@@ -307,10 +307,10 @@ static void intel_vblank_section_enter(struct drm_i915_private *i915)
 	__acquires(i915->uncore.lock)
 {
 #ifdef I915
+	spin_lock(&i915->uncore.lock);
 #ifdef __FreeBSD__
 	preempt_disable();
 #endif
-	spin_lock(&i915->uncore.lock);
 #endif
 }
 
@@ -318,10 +318,10 @@ static void intel_vblank_section_exit(struct drm_i915_private *i915)
 	__releases(i915->uncore.lock)
 {
 #ifdef I915
-	spin_unlock(&i915->uncore.lock);
 #ifdef __FreeBSD__
 	preempt_enable();
 #endif
+	spin_unlock(&i915->uncore.lock);
 #endif
 }
 


### PR DESCRIPTION
The idea is that after `intel_vblank_section_enter()`, we are in a critical section.

The initial fix was supposed to address a panic occurring because `spin_lock()` is a FreeBSD mutex underneath and it can't be acquired in a critical section. But the order was wrong: the critical section was entered just before acquiring the mutex, leading to the same panic. Because the panic occurs infrequently, the error in the fix was not spotted during testing.

The new fix consists of swapping the order, so that the critical section is entered AFTER acquiring the mutex.

Fixes #424.