### PR TITLE
compiler_flags.mk: Silence warning from Clang 21 (DRM 5.15)

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -7,6 +7,7 @@ KMOD=	amdgpu
 
 .include "../../kconfig.mk"
 .include "../../linuxkpi_version.mk"
+.include "../../compiler_flags.mk"
 
 .if !empty(KCONFIG:MDRM_AMD_DC_DCN*)
 _dml=	${SRCDIR}/display/dc/dml \

--- a/compiler_flags.mk
+++ b/compiler_flags.mk
@@ -1,6 +1,25 @@
+# To set some flags, we need to know the type and the version of the compiler.
+# If these variables are not set, figure out their value here. This code was
+# copied from `Mk/Uses/compiler.mk` from the FreeBSD ports tree.
+.if !defined(COMPILER_TYPE)
+_CCVERSION!=	${CC} --version
+COMPILER_VERSION=	${_CCVERSION:M[0-9]*.[0-9]*:[1]:C/([0-9]+)\.([0-9]+)\..*/\1\2/}
+.  if ${_CCVERSION:Mclang}
+COMPILER_TYPE=	clang
+.  else
+COMPILER_TYPE=	gcc
+.  endif
+.endif
+
 # Linux' Makefile (scripts/Makefile.lib) always include
 # <linux/compiler_types.h> from the compiler command line.
 #
 # At least `drivers/gpu/drm/drm_atomic_uapi.c` and
 # `include/drm/drm_atomic_uap.h` depends on this to compile.
 CFLAGS+=	-include ${SYSDIR}/compat/linuxkpi/common/include/linux/compiler_types.h
+
+# Globally silence a new warning from Clang 21.
+# See https://lkml.org/lkml/2025/5/6/1681.
+.if ${COMPILER_TYPE} == clang && ${COMPILER_VERSION} >= 211
+CWARNFLAGS+=	-Wno-default-const-init-var-unsafe
+.endif

--- a/compiler_flags.mk
+++ b/compiler_flags.mk
@@ -1,0 +1,6 @@
+# Linux' Makefile (scripts/Makefile.lib) always include
+# <linux/compiler_types.h> from the compiler command line.
+#
+# At least `drivers/gpu/drm/drm_atomic_uapi.c` and
+# `include/drm/drm_atomic_uap.h` depends on this to compile.
+CFLAGS+=	-include ${SYSDIR}/compat/linuxkpi/common/include/linux/compiler_types.h

--- a/dmabuf/Makefile
+++ b/dmabuf/Makefile
@@ -4,6 +4,7 @@ SRCDIR=	${.CURDIR:H}/drivers/dma-buf
 
 .include "../kconfig.mk"
 .include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
 
 KMOD=	dmabuf
 SRCS=	dma-buf-kmod.c \

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -6,6 +6,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm
 
 .include "../kconfig.mk"
 .include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
 
 KMOD=	drm
 SRCS=	drm_atomic.c \

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -6,6 +6,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/i915
 
 .include "../kconfig.mk"
 .include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
 
 KMOD=	i915kms
 SRCS=	\

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -6,6 +6,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/radeon
 
 .include "../kconfig.mk"
 .include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
 
 KMOD=	radeonkms
 SRCS=	atom.c \

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -6,6 +6,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/ttm
 
 .include "../kconfig.mk"
 .include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
 
 KMOD=	ttm
 SRCS=	ttm_bo.c \


### PR DESCRIPTION
Clang 21 emits the following new warning:

    error: default initialization of an object of type (...) leaves the object uninitialized [-Werror,-Wdefault-const-init-var-unsafe]

Linux disables this warning globally. Let's do the same.

The original patch was committed to the FreeBSD Ports tree by dim@.

See https://lkml.org/lkml/2025/5/6/1681.

References #429.