### PR TITLE
drm/amd/display: bracket DML2 creation with DC_FP_START/END

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/core/dc_state.c
+++ b/drivers/gpu/drm/amd/display/dc/core/dc_state.c
@@ -211,10 +211,14 @@ struct dc_state *dc_state_create(struct dc *dc, struct dc_state_create_params *p
 #ifdef CONFIG_DRM_AMD_DC_FP
 	if (dc->debug.using_dml2) {
 		dml2_opt->use_clock_dc_limits = false;
+		DC_FP_START();
 		dml2_create(dc, dml2_opt, &state->bw_ctx.dml2);
+		DC_FP_END();
 
 		dml2_opt->use_clock_dc_limits = true;
+		DC_FP_START();
 		dml2_create(dc, dml2_opt, &state->bw_ctx.dml2_dc_power_source);
+		DC_FP_END();
 	}
 #endif
 
@@ -259,16 +263,28 @@ struct dc_state *dc_state_create_copy(struct dc_state *src_state)
 	dc_state_copy_internal(new_state, src_state);
 
 #ifdef CONFIG_DRM_AMD_DC_FP
-	if (src_state->bw_ctx.dml2 &&
-			!dml2_create_copy(&new_state->bw_ctx.dml2, src_state->bw_ctx.dml2)) {
-		dc_state_release(new_state);
-		return NULL;
+	if (src_state->bw_ctx.dml2) {
+		bool dml2_ok;
+
+		DC_FP_START();
+		dml2_ok = dml2_create_copy(&new_state->bw_ctx.dml2, src_state->bw_ctx.dml2);
+		DC_FP_END();
+		if (!dml2_ok) {
+			dc_state_release(new_state);
+			return NULL;
+		}
 	}
 
-	if (src_state->bw_ctx.dml2_dc_power_source &&
-			!dml2_create_copy(&new_state->bw_ctx.dml2_dc_power_source, src_state->bw_ctx.dml2_dc_power_source)) {
-		dc_state_release(new_state);
-		return NULL;
+	if (src_state->bw_ctx.dml2_dc_power_source) {
+		bool dml2_ok;
+
+		DC_FP_START();
+		dml2_ok = dml2_create_copy(&new_state->bw_ctx.dml2_dc_power_source, src_state->bw_ctx.dml2_dc_power_source);
+		DC_FP_END();
+		if (!dml2_ok) {
+			dc_state_release(new_state);
+			return NULL;
+		}
 	}
 #endif
 

--- a/drivers/gpu/drm/amd/display/dc/resource/dcn35/dcn35_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/resource/dcn35/dcn35_resource.c
@@ -1738,9 +1738,11 @@ static bool dcn35_validate_bandwidth(struct dc *dc,
 {
 	bool out = false;
 
+	DC_FP_START();
 	out = dml2_validate(dc, context,
 			context->power_source == DC_POWER_SOURCE_DC ? context->bw_ctx.dml2_dc_power_source : context->bw_ctx.dml2,
 			fast_validate);
+	DC_FP_END();
 
 	if (fast_validate)
 		return out;

--- a/drivers/gpu/drm/amd/display/dc/resource/dcn351/dcn351_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/resource/dcn351/dcn351_resource.c
@@ -1718,9 +1718,11 @@ static bool dcn351_validate_bandwidth(struct dc *dc,
 {
 	bool out = false;
 
+	DC_FP_START();
 	out = dml2_validate(dc, context,
 			context->power_source == DC_POWER_SOURCE_DC ? context->bw_ctx.dml2_dc_power_source : context->bw_ctx.dml2,
 			fast_validate);
+	DC_FP_END();
 
 	if (fast_validate)
 		return out;

--- a/drivers/gpu/drm/amd/display/dc/resource/dcn401/dcn401_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/resource/dcn401/dcn401_resource.c
@@ -1611,10 +1611,13 @@ bool dcn401_validate_bandwidth(struct dc *dc,
 		bool fast_validate)
 {
 	bool out = false;
-	if (dc->debug.using_dml2)
+	if (dc->debug.using_dml2) {
+		DC_FP_START();
 		out = dml2_validate(dc, context,
 				context->power_source == DC_POWER_SOURCE_DC ? context->bw_ctx.dml2_dc_power_source : context->bw_ctx.dml2,
 				fast_validate);
+		DC_FP_END();
+	}
 	return out;
 }
 


### PR DESCRIPTION
The dml2_create() calls in dc_state_create() and the dml2_create_copy() calls in dc_state_create_copy() perform floating-point math (display mode bandwidth/clocks calculation in initialize_dml2_soc_bbox and friends) without first entering an FPU-safe section.

On Linux this happens to work because the kernel handles FPU state lazily, but on FreeBSD the LKPI requires every kernel FPU user to call kernel_fpu_begin()/kernel_fpu_end() (exposed here as DC_FP_START() / DC_FP_END()). Without them the kernel panics with:

panic: Unregistered use of FPU in kernel

triggered from dml2_init_socbb_params() during amdgpu_dm_init() on DCN 3.5 hardware (AMD Strix Halo / Radeon 8060S).

Wrap both dml2_create() call sites and both dml2_create_copy() call sites with DC_FP_START()/DC_FP_END(). The dml2_create_copy() blocks are slightly restructured so the FP guard cleanly brackets just the call, with the success check moved out.

Tested on FreeBSD 16.0-CURRENT with a Framework Desktop (Strix Halo, DCN 3.5.1): amdgpu loads and initializes the display core without panicking.