### PR TITLE
drm/i915: Fix "mi_switch: switch in a critical section" panic

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_vblank.c
+++ b/drivers/gpu/drm/i915/display/intel_vblank.c
@@ -307,10 +307,10 @@ static void intel_vblank_section_enter(struct drm_i915_private *i915)
 	__acquires(i915->uncore.lock)
 {
 #ifdef I915
+	spin_lock(&i915->uncore.lock);
 #ifdef __FreeBSD__
 	preempt_disable();
 #endif
-	spin_lock(&i915->uncore.lock);
 #endif
 }
 
@@ -318,10 +318,10 @@ static void intel_vblank_section_exit(struct drm_i915_private *i915)
 	__releases(i915->uncore.lock)
 {
 #ifdef I915
-	spin_unlock(&i915->uncore.lock);
 #ifdef __FreeBSD__
 	preempt_enable();
 #endif
+	spin_unlock(&i915->uncore.lock);
 #endif
 }
 


### PR DESCRIPTION
`spin_lock()`, which is a FreeBSD mutex underneath, can sleep. Therefore, we can't enter a critical section just before calling `spin_lock()`.

The expectation is that at the end of `intel_vblank_section_enter()`, the lock is acquired and preemption is disabled. On Linux, this is part of `spin_lock()`, but on FreeBSD, we can simply enter the critical section after acquiring the lock.

Fixes #424.