### PR TITLE
Arrange order of .include in Makefiles again [FreeBSD]

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -1,4 +1,5 @@
-# $FreeBSD$
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../../kconfig.mk"
 
 SRCDIR=	${.CURDIR:H:H}/drivers/gpu/drm/amd
 DRM= ${.CURDIR:H:H}/drivers/gpu/drm
@@ -11,10 +12,6 @@ KMOD=	amdgpu
 # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276828
 #
 MK_CTF=	no
-
-.include "../../kconfig.mk"
-.include "../../linuxkpi_version.mk"
-.include "../../compiler_flags.mk"
 
 .if !empty(KCONFIG:MDRM_AMD_DC_FP)
 _dml=	${SRCDIR}/display/dc/dml \
@@ -1258,6 +1255,13 @@ SRCS+=	device_if.h \
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
+.include <bsd.kmod.mk>
+
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
+.include "../../linuxkpi_version.mk"
+.include "../../compiler_flags.mk"
+
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/bsd/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
@@ -1328,8 +1332,6 @@ CFLAGS+= -I${DRM}/scheduler
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
 CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=amdgpu_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD}
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
-
-.include <bsd.kmod.mk>
 
 CFLAGS.gcc+= -Wno-redundant-decls -Wno-unused-but-set-variable
 

--- a/amd/amdkfd/Makefile
+++ b/amd/amdkfd/Makefile
@@ -1,4 +1,5 @@
-# $FreeBSD$
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../../kconfig.mk"
 
 SRCDIR=	${.CURDIR:H:H}/drivers/gpu/drm/amd
 
@@ -49,6 +50,13 @@ SRCS+=	device_if.h \
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
+.include <bsd.kmod.mk>
+
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
+.include "../../linuxkpi_version.mk"
+.include "../../compiler_flags.mk"
+
 CFLAGS+= -I${.CURDIR:H:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/dummy/include
@@ -67,8 +75,6 @@ CFLAGS+= -I${SRCDIR}/include/asic_reg
 
 CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=amdkfd_'
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
-
-.include <bsd.kmod.mk>
 
 CWARNFLAGS+=	-Wno-pointer-arith
 CWARNFLAGS+=	${CWARNFLAGS.${.IMPSRC:T}}

--- a/compiler_flags.mk
+++ b/compiler_flags.mk
@@ -1,9 +1,11 @@
+.if exists(${SYSDIR}/compat/linuxkpi/common/include/linux/compiler_types.h)
 # Linux' Makefile (scripts/Makefile.lib) always include
 # <linux/compiler_types.h> from the compiler command line.
 #
 # At least `drivers/gpu/drm/drm_atomic_uapi.c` and
 # `include/drm/drm_atomic_uap.h` depends on this to compile.
 CFLAGS+=	-include ${SYSDIR}/compat/linuxkpi/common/include/linux/compiler_types.h
+.endif
 
 CWARNFLAGS+=	-Wno-pointer-sign
 

--- a/compiler_flags.mk
+++ b/compiler_flags.mk
@@ -1,16 +1,3 @@
-# To set some flags, we need to know the type and the version of the compiler.
-# If these variables are not set, figure out their value here. This code was
-# copied from `Mk/Uses/compiler.mk` from the FreeBSD ports tree.
-.if !defined(COMPILER_TYPE)
-_CCVERSION!=	${CC} --version
-COMPILER_VERSION=	${_CCVERSION:M[0-9]*.[0-9]*:[1]:C/([0-9]+)\.([0-9]+)\..*/\1\2/}
-.  if ${_CCVERSION:Mclang}
-COMPILER_TYPE=	clang
-.  else
-COMPILER_TYPE=	gcc
-.  endif
-.endif
-
 # Linux' Makefile (scripts/Makefile.lib) always include
 # <linux/compiler_types.h> from the compiler command line.
 #
@@ -22,6 +9,6 @@ CWARNFLAGS+=	-Wno-pointer-sign
 
 # Globally silence a new warning from Clang 21.
 # See https://lkml.org/lkml/2025/5/6/1681.
-.if ${COMPILER_TYPE} == clang && ${COMPILER_VERSION} >= 211
+.if ${COMPILER_TYPE} == clang && ${COMPILER_VERSION} >= 210100
 CWARNFLAGS+=	-Wno-default-const-init-var-unsafe
 .endif

--- a/dmabuf/Makefile
+++ b/dmabuf/Makefile
@@ -1,10 +1,9 @@
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../kconfig.mk"
+
 SRCDIR=	${.CURDIR:H}/drivers/dma-buf
 
 .PATH:	${SRCDIR}
-
-.include "../kconfig.mk"
-.include "../linuxkpi_version.mk"
-.include "../compiler_flags.mk"
 
 KMOD=	dmabuf
 SRCS=	dma-buf-kmod.c \
@@ -22,6 +21,13 @@ SRCS+=	device_if.h \
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
+.include <bsd.kmod.mk>
+
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
+.include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
+
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/bsd/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
@@ -33,5 +39,3 @@ CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 CWARNFLAGS.dma-buf.c+=	-Wno-pointer-arith
 
 EXPORT_SYMS=	YES
-
-.include <bsd.kmod.mk>

--- a/drivers/gpu/drm/drm_fb_helper.c
+++ b/drivers/gpu/drm/drm_fb_helper.c
@@ -522,7 +522,9 @@ struct fb_info *drm_fb_helper_alloc_info(struct drm_fb_helper *fb_helper)
 {
 	struct device *dev = fb_helper->dev->dev;
 	struct fb_info *info;
+#ifdef __linux__
 	int ret;
+#endif
 
 	info = framebuffer_alloc(0, dev);
 	if (!info)
@@ -541,10 +543,12 @@ struct fb_info *drm_fb_helper_alloc_info(struct drm_fb_helper *fb_helper)
 	info->skip_vt_switch = true;
 
 	return info;
+#ifdef __linux__
 
 err_release:
 	framebuffer_release(info);
 	return ERR_PTR(ret);
+#endif
 }
 EXPORT_SYMBOL(drm_fb_helper_alloc_info);
 
@@ -1353,7 +1357,9 @@ EXPORT_SYMBOL(drm_fb_helper_check_var);
 int drm_fb_helper_set_par(struct fb_info *info)
 {
 	struct drm_fb_helper *fb_helper = info->par;
+#ifdef __linux__
 	struct fb_var_screeninfo *var = &info->var;
+#endif
 	bool force;
 
 	if (oops_in_progress)

--- a/drivers/gpu/drm/drm_fbdev_ttm.c
+++ b/drivers/gpu/drm/drm_fbdev_ttm.c
@@ -131,8 +131,10 @@ static int drm_fbdev_ttm_helper_fb_probe(struct drm_fb_helper *fb_helper,
 
 	return 0;
 
+#ifdef __linux__
 err_drm_fb_helper_release_info:
 	drm_fb_helper_release_info(fb_helper);
+#endif
 err_vfree:
 	vfree(screen_buffer);
 err_drm_client_framebuffer_delete:

--- a/drivers/gpu/drm/ttm/ttm_pool.c
+++ b/drivers/gpu/drm/ttm/ttm_pool.c
@@ -83,10 +83,14 @@ static DECLARE_RWSEM(pool_shrink_rwsem);
 static struct page *ttm_pool_alloc_page(struct ttm_pool *pool, gfp_t gfp_flags,
 					unsigned int order)
 {
+#ifdef __linux__
 	unsigned long attr = DMA_ATTR_FORCE_CONTIGUOUS;
 	struct ttm_pool_dma *dma;
+#endif
 	struct page *p;
+#ifdef __linux__
 	void *vaddr;
+#endif
 
 	/* Don't set the __GFP_COMP flag for higher order allocations.
 	 * Mapping pages directly into an userspace process and calling
@@ -130,22 +134,25 @@ static struct page *ttm_pool_alloc_page(struct ttm_pool *pool, gfp_t gfp_flags,
 	p->private = (unsigned long)dma;
 	return p;
 #elif defined(__FreeBSD__)
-	dma = NULL;
 	panic("ttm_pool.c: use_dma_alloc not implemented");
 #endif
 
+#ifdef __linux__
 error_free:
 	kfree(dma);
 	return NULL;
+#endif
 }
 
 /* Reset the caching and pages of size 1 << order */
 static void ttm_pool_free_page(struct ttm_pool *pool, enum ttm_caching caching,
 			       unsigned int order, struct page *p)
 {
+#ifdef __linux__
 	unsigned long attr = DMA_ATTR_FORCE_CONTIGUOUS;
 	struct ttm_pool_dma *dma;
 	void *vaddr;
+#endif
 
 #ifdef CONFIG_X86
 	/* We don't care that set_pages_wb is inefficient here. This is only
@@ -160,10 +167,10 @@ static void ttm_pool_free_page(struct ttm_pool *pool, enum ttm_caching caching,
 		return;
 	}
 
+#ifdef __linux__
 	if (order)
 		attr |= DMA_ATTR_NO_WARN;
 
-#ifdef __linux__
 	dma = (void *)p->private;
 	vaddr = (void *)(dma->vaddr & PAGE_MASK);
 	dma_free_attrs(pool->dev, (1UL << order) * PAGE_SIZE, vaddr, dma->addr,

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -1,5 +1,8 @@
 # $FreeBSD$
 
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../kconfig.mk"
+
 SRCDIR=	${.CURDIR:H}/drivers/gpu/drm
 
 .PATH:	${SRCDIR} ${SRCDIR}/display ${SRCDIR}/scheduler
@@ -147,7 +150,8 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 .include <bsd.kmod.mk>
 
-.include "../kconfig.mk"
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
 .include "../linuxkpi_version.mk"
 .include "../compiler_flags.mk"
 
@@ -183,6 +187,7 @@ CWARNFLAGS.drm_gem_framebuffer_helper.c+=	-Wno-missing-prototypes
 CWARNFLAGS.drm_hdcp_helper.c+=			-Wno-cast-qual
 CWARNFLAGS.drm_ioc32.c+=			-Wno-address-of-packed-member
 CWARNFLAGS.drm_mm.c+=				-Wno-cast-qual -Wno-unused-function
+CWARNFLAGS.drm_panel_orientation_quirks.c+=	-Wno-cast-qual
 CWARNFLAGS.drm_syncobj.c+=			-Wno-unused-variable
 
 EXPORT_SYMS=	YES

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -1,8 +1,5 @@
 # $FreeBSD$
 
-.include "../kconfig.mk"
-.include "../linuxkpi_version.mk"
-
 SRCDIR=	${.CURDIR:H}/drivers/gpu/drm
 
 .PATH:	${SRCDIR} ${SRCDIR}/display ${SRCDIR}/scheduler
@@ -150,6 +147,8 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 .include <bsd.kmod.mk>
 
+.include "../kconfig.mk"
+.include "../linuxkpi_version.mk"
 .include "../compiler_flags.mk"
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
@@ -177,17 +176,13 @@ CWARNFLAGS.drm_dp_mst_topology.c+=		-Wno-missing-prototypes
 CWARNFLAGS.drm_dp_tunnel.c+=			-Wno-incompatible-pointer-types-discards-qualifiers
 CWARNFLAGS.drm_drv.c+=				-Wno-unused-variable
 CWARNFLAGS.drm_edid.c+=				-Wno-cast-qual
-CWARNFLAGS.drm_fb_helper.c+=			-Wno-unused-variable -Wno-unused-label
-CWARNFLAGS.drm_fbdev_ttm.c+=			-Wno-unused-variable -Wno-unused-label
 CWARNFLAGS.drm_file.c+=				-Wno-unused-but-set-variable
 CWARNFLAGS.drm_file.c+=				-Wno-unused-value
 CWARNFLAGS.drm_gem_atomic_helper.c+=		-Wno-missing-prototypes
 CWARNFLAGS.drm_gem_framebuffer_helper.c+=	-Wno-missing-prototypes
 CWARNFLAGS.drm_hdcp_helper.c+=			-Wno-cast-qual
 CWARNFLAGS.drm_ioc32.c+=			-Wno-address-of-packed-member
-CWARNFLAGS.drm_mipi_dsi.c+=			-Wno-missing-prototypes
 CWARNFLAGS.drm_mm.c+=				-Wno-cast-qual -Wno-unused-function
-CWARNFLAGS.drm_panel_orientation_quirks.c+=	-Wno-cast-qual
 CWARNFLAGS.drm_syncobj.c+=			-Wno-unused-variable
 
 EXPORT_SYMS=	YES

--- a/dummygfx/Makefile
+++ b/dummygfx/Makefile
@@ -1,4 +1,5 @@
-# $FreeBSD$
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../kconfig.mk"
 
 SRCDIR=	${.CURDIR}
 
@@ -25,6 +26,13 @@ SRCS	+=			\
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
+.include <bsd.kmod.mk>
+
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
+.include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
+
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
 
@@ -38,7 +46,5 @@ CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=dummygfx_'
 CFLAGS+= -include ${SRCDIR:H}/drivers/gpu/drm/drm_os_config.h
 
 EXPORT_SYMS=	YES
-
-.include <bsd.kmod.mk>
 
 CWARNFLAGS += -Wno-cast-qual

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -1,4 +1,5 @@
-# $FreeBSD$
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../kconfig.mk"
 
 SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/i915
 
@@ -356,10 +357,10 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 .include <bsd.kmod.mk>
 
-.include "../kconfig.mk"
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
 .include "../linuxkpi_version.mk"
 .include "../compiler_flags.mk"
-
 
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/bsd/include

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -1,8 +1,5 @@
 # $FreeBSD$
 
-.include "../kconfig.mk"
-.include "../linuxkpi_version.mk"
-
 SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/i915
 
 .PATH:	${SRCDIR} \
@@ -359,6 +356,8 @@ CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
 .include <bsd.kmod.mk>
 
+.include "../kconfig.mk"
+.include "../linuxkpi_version.mk"
 .include "../compiler_flags.mk"
 
 

--- a/include/drm/drm_mipi_dsi.h
+++ b/include/drm/drm_mipi_dsi.h
@@ -72,22 +72,89 @@ enum mipi_dsi_compression_algo {
 	MIPI_DSI_COMPRESSION_VENDOR = 3,
 };
 
-int mipi_dsi_attach(struct mipi_dsi_device *);
+bool mipi_dsi_packet_format_is_short(u8);
+bool mipi_dsi_packet_format_is_long(u8);
+
 int mipi_dsi_create_packet(struct mipi_dsi_packet *,
     const struct mipi_dsi_msg *);
-ssize_t mipi_dsi_generic_write(struct mipi_dsi_device *, const void *, size_t);
-ssize_t mipi_dsi_dcs_write_buffer(struct mipi_dsi_device *, const void *,
-    size_t);
-ssize_t mipi_dsi_dcs_read(struct mipi_dsi_device *, u8, void *, size_t);
-ssize_t mipi_dsi_dcs_write(struct mipi_dsi_device *, u8, const void *, size_t);
-int mipi_dsi_dcs_nop(struct mipi_dsi_device *);
+
+int mipi_dsi_host_register(struct mipi_dsi_host *);
+void mipi_dsi_host_unregister(struct mipi_dsi_host *);
+
+void mipi_dsi_device_unregister(struct mipi_dsi_device *);
+int mipi_dsi_attach(struct mipi_dsi_device *);
+int mipi_dsi_detach(struct mipi_dsi_device *);
+int devm_mipi_dsi_attach(struct device *, struct mipi_dsi_device *);
+int mipi_dsi_shutdown_peripheral(struct mipi_dsi_device *);
+int mipi_dsi_turn_on_peripheral(struct mipi_dsi_device *);
 int mipi_dsi_set_maximum_return_packet_size(struct mipi_dsi_device *, u16);
-bool mipi_dsi_packet_format_is_long(u8);
 int mipi_dsi_compression_mode(struct mipi_dsi_device *, bool);
-int mipi_dsi_compression_mode_ext(struct mipi_dsi_device *dsi, bool enable,
-    enum mipi_dsi_compression_algo algo, unsigned int pps_selector);
+int mipi_dsi_compression_mode_ext(struct mipi_dsi_device *, bool,
+    enum mipi_dsi_compression_algo, unsigned int);
 int mipi_dsi_picture_parameter_set(struct mipi_dsi_device *,
     const struct drm_dsc_picture_parameter_set *);
+
+void mipi_dsi_compression_mode_ext_multi(struct mipi_dsi_multi_context *,
+    bool, enum mipi_dsi_compression_algo, unsigned int);
+void mipi_dsi_picture_parameter_set_multi(struct mipi_dsi_multi_context *,
+    const struct drm_dsc_picture_parameter_set *);
+
+ssize_t mipi_dsi_generic_write(struct mipi_dsi_device *, const void *, size_t);
+int mipi_dsi_generic_write_chatty(struct mipi_dsi_device *,
+    const void *, size_t);
+void mipi_dsi_generic_write_multi(struct mipi_dsi_multi_context *,
+    const void *, size_t);
+ssize_t mipi_dsi_generic_read(struct mipi_dsi_device *,
+    const void *, size_t, void *, size_t);
+
+ssize_t mipi_dsi_dcs_write_buffer(struct mipi_dsi_device *,
+    const void *, size_t);
+int mipi_dsi_dcs_write_buffer_chatty(struct mipi_dsi_device *,
+    const void *, size_t);
+void mipi_dsi_dcs_write_buffer_multi(struct mipi_dsi_multi_context *,
+				     const void *, size_t);
+ssize_t mipi_dsi_dcs_write(struct mipi_dsi_device *, u8,
+    const void *, size_t);
+ssize_t mipi_dsi_dcs_read(struct mipi_dsi_device *, u8,
+    void *, size_t);
+int mipi_dsi_dcs_nop(struct mipi_dsi_device *);
+int mipi_dsi_dcs_soft_reset(struct mipi_dsi_device *);
+int mipi_dsi_dcs_get_power_mode(struct mipi_dsi_device *, u8 *);
+int mipi_dsi_dcs_get_pixel_format(struct mipi_dsi_device *, u8 *);
+int mipi_dsi_dcs_enter_sleep_mode(struct mipi_dsi_device *);
+int mipi_dsi_dcs_exit_sleep_mode(struct mipi_dsi_device *);
+int mipi_dsi_dcs_set_display_off(struct mipi_dsi_device *);
+int mipi_dsi_dcs_set_display_on(struct mipi_dsi_device *);
+int mipi_dsi_dcs_set_column_address(struct mipi_dsi_device *, u16, u16);
+int mipi_dsi_dcs_set_page_address(struct mipi_dsi_device *, u16, u16);
+int mipi_dsi_dcs_set_tear_off(struct mipi_dsi_device *);
+int mipi_dsi_dcs_set_tear_on(struct mipi_dsi_device *,
+    enum mipi_dsi_dcs_tear_mode);
+int mipi_dsi_dcs_set_pixel_format(struct mipi_dsi_device *, u8);
+int mipi_dsi_dcs_set_tear_scanline(struct mipi_dsi_device *, u16);
+int mipi_dsi_dcs_set_display_brightness(struct mipi_dsi_device *, u16);
+int mipi_dsi_dcs_get_display_brightness(struct mipi_dsi_device *, u16 *);
+int mipi_dsi_dcs_set_display_brightness_large(struct mipi_dsi_device *, u16);
+int mipi_dsi_dcs_get_display_brightness_large(struct mipi_dsi_device *, u16 *);
+
+void mipi_dsi_dcs_nop_multi(struct mipi_dsi_multi_context *);
+void mipi_dsi_dcs_enter_sleep_mode_multi(struct mipi_dsi_multi_context *);
+void mipi_dsi_dcs_exit_sleep_mode_multi(struct mipi_dsi_multi_context *);
+void mipi_dsi_dcs_set_display_off_multi(struct mipi_dsi_multi_context *);
+void mipi_dsi_dcs_set_display_on_multi(struct mipi_dsi_multi_context *);
+void mipi_dsi_dcs_set_tear_on_multi(struct mipi_dsi_multi_context *,
+    enum mipi_dsi_dcs_tear_mode);
+void mipi_dsi_turn_on_peripheral_multi(struct mipi_dsi_multi_context *);
+void mipi_dsi_dcs_soft_reset_multi(struct mipi_dsi_multi_context *);
+void mipi_dsi_dcs_set_display_brightness_multi(struct mipi_dsi_multi_context *,
+    u16);
+void mipi_dsi_dcs_set_pixel_format_multi(struct mipi_dsi_multi_context *, u8);
+void mipi_dsi_dcs_set_column_address_multi(struct mipi_dsi_multi_context *,
+    u16, u16);
+void mipi_dsi_dcs_set_page_address_multi(struct mipi_dsi_multi_context *,
+    u16, u16);
+void mipi_dsi_dcs_set_tear_scanline_multi(struct mipi_dsi_multi_context *,
+    u16);
 
 static inline int
 mipi_dsi_pixel_format_to_bpp(enum mipi_dsi_pixel_format fmt)

--- a/linuxkpi/gplv2/include/linux/fb.h
+++ b/linuxkpi/gplv2/include/linux/fb.h
@@ -283,7 +283,11 @@ int remove_conflicting_framebuffers(struct apertures_struct *a,
 int remove_conflicting_pci_framebuffers(struct pci_dev *pdev, const char *name);
 struct linux_fb_info *framebuffer_alloc(size_t size, struct device *dev);
 void framebuffer_release(struct linux_fb_info *info);
-#define	fb_set_suspend(x, y)	0
+
+static inline void
+fb_set_suspend(struct linux_fb_info *info, int state)
+{
+}
 
 static inline bool
 is_firmware_framebuffer(struct apertures_struct *a __unused)

--- a/linuxkpi_video/Makefile
+++ b/linuxkpi_video/Makefile
@@ -1,10 +1,9 @@
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../kconfig.mk"
+
 SRCDIR=	${.CURDIR:H}/drivers/video
 
 .PATH:	${SRCDIR}
-
-.include "../kconfig.mk"
-.include "../linuxkpi_version.mk"
-.include "../compiler_flags.mk"
 
 KMOD=	linuxkpi_video
 SRCS=	hdmi.c \
@@ -23,6 +22,13 @@ SRCS+=	bus_if.h \
 	pci_if.h \
 	vnode_if.h \
 
+.include <bsd.kmod.mk>
+
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
+.include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
+
 CFLAGS+=	-I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+=	-I${.CURDIR:H}/linuxkpi/bsd/include
 CFLAGS+=	-I${SYSDIR}/compat/linuxkpi/common/include
@@ -36,5 +42,3 @@ CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 CWARNFLAGS.hdmi.c=	-Wno-cast-qual
 
 EXPORT_SYMS=    YES
-
-.include <bsd.kmod.mk>

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -1,12 +1,9 @@
-# $FreeBSD$
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../kconfig.mk"
 
 SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/radeon
 
 .PATH:	${SRCDIR}
-
-.include "../kconfig.mk"
-.include "../linuxkpi_version.mk"
-.include "../compiler_flags.mk"
 
 KMOD=	radeonkms
 SRCS=	atom.c \
@@ -128,6 +125,13 @@ SRCS+=	device_if.h \
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
+.include <bsd.kmod.mk>
+
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
+.include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
+
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/bsd/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
@@ -145,8 +149,6 @@ CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 CFLAGS.gcc+= -Wno-redundant-decls -Wno-cast-qual -Wno-unused-but-set-variable \
 	-Wno-maybe-uninitialized
-
-.include <bsd.kmod.mk>
 
 CWARNFLAGS+= -Wno-format
 CWARNFLAGS+= -Wno-expansion-to-defined

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -1,12 +1,9 @@
-# $FreeBSD$
+# `kconfig.mk` defines variables used to conditionally add files to $(SRCS).
+.include "../kconfig.mk"
 
 SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/ttm
 
 .PATH:	${SRCDIR} ${SRCDIR}/..
-
-.include "../kconfig.mk"
-.include "../linuxkpi_version.mk"
-.include "../compiler_flags.mk"
 
 KMOD=	ttm
 SRCS=	ttm_bo.c \
@@ -39,6 +36,13 @@ SRCS+=	device_if.h \
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
+.include <bsd.kmod.mk>
+
+# These Makefiles are included after <bsd.kmod.mk> because they expand
+# variables defined by it.
+.include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
+
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/bsd/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
@@ -60,5 +64,3 @@ CWARNFLAGS+= -Wno-pointer-arith -Wno-format
 CWARNFLAGS+= -Wno-expansion-to-defined
 
 EXPORT_SYMS=	YES
-
-.include <bsd.kmod.mk>

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -6,6 +6,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/ttm
 
 .include "../kconfig.mk"
 .include "../linuxkpi_version.mk"
+.include "../compiler_flags.mk"
 
 KMOD=	ttm
 SRCS=	ttm_bo.c \
@@ -38,10 +39,6 @@ SRCS+=	device_if.h \
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 
-.include <bsd.kmod.mk>
-
-.include "../compiler_flags.mk"
-
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/gplv2/include
 CFLAGS+= -I${.CURDIR:H}/linuxkpi/bsd/include
 CFLAGS+= -I${SYSDIR}/compat/linuxkpi/common/include
@@ -62,6 +59,6 @@ CWARNFLAGS+=-Wno-cast-qual
 CWARNFLAGS+= -Wno-pointer-arith -Wno-format
 CWARNFLAGS+= -Wno-expansion-to-defined
 
-CWARNFLAGS.ttm_pool.c+=		-Wno-unused-variable -Wno-unused-label -Wno-unused-but-set-variable
-
 EXPORT_SYMS=	YES
+
+.include <bsd.kmod.mk>


### PR DESCRIPTION
Our local `.include` should not be grouped together:

* `kconfig.mk` defines variables used to conditionally add files to `$(SRCS)`. `$(SRCS)` must be defined before the inclusion of `<bsd.kmod.mk>` because it is an input variable.
* `linuxkpi_version.mk` and `compiler_flags.mk` expand variables initialized by `<bsd.kmod.mk>`. Therefore, they should be included after.

All Makefiles are unified to do the same thing:
1. Include `kconfig.mk`
2. Defined input variables of `<bsd.kmod.mk>` like `$(SRCS)`
3. Include `<bsd.kmod.mk>`
4. Include `linuxkpi_version.mk` and `compiler_flags.mk` to expand output variables of `<bsd.kmod.mk>`
5. Define or expand whatever is needed.

At the same time, fix `compiler_flags.mk` now that the above has been cleaned up:
* Do not define `$(COMPILER_TYPE)` and `$(COMPILER_VERSION)` as they are already set by `<bsd.kmod.mk>`.
* Use the proper version format when comparing `$(COMPILER_VERSION)`.

A change in linuxkpi in freebsd-src in also required to fix another "unused variable" variable. See the following review:
https://reviews.freebsd.org/D56780

References #438.
Fixes #440, #443.

Sponsored by:   The FreeBSD Foundation

**V2**: Revert 7ae5c93b6a508d939156cd75bb1785ce960478db, 1a1cbfe38f728f8625746e946fd482f17b35e9e9 and 6ca103613f3ab224a1eae888b3c665fb28820d0a as part of this pull request. The warnings are genuine and should be addressed instead of ignored.