### PR TITLE
drm/i915: Restore default setting for `enable_guc` again [FreeBSD]

### DIFF
--- a/drivers/gpu/drm/i915/gt/uc/intel_uc.c
+++ b/drivers/gpu/drm/i915/gt/uc/intel_uc.c
@@ -42,18 +42,25 @@ static void uc_expand_default_options(struct intel_uc *uc)
 		return;
 	}
 
-#ifndef __FreeBSD__
-	/* FreeBSD FIXME */
-	/* GuC is known to be broken so disable it for GEN12 for now */
-
 	/* Intermediate platforms are HuC authentication only */
 	if (IS_ALDERLAKE_S(i915) && !IS_RAPTORLAKE_S(i915)) {
 		i915->params.enable_guc = ENABLE_GUC_LOAD_HUC;
 		return;
 	}
 
+#ifdef __linux__
 	/* Default: enable HuC authentication and GuC submission */
 	i915->params.enable_guc = ENABLE_GUC_LOAD_HUC | ENABLE_GUC_SUBMISSION;
+#elif defined(__FreeBSD__)
+	/*
+	 * FIXME:
+	 * On FreeBSD, when GUC submission is enabled, there is a great chance
+	 * that the computer refuses to power off when asked to do so. Like
+	 * after a `shutdown -p now`, the kernel stops everything, the display
+	 * is turned off, but the power LED is still on and the fans are
+	 * running. The computer is obviously unreachable.
+	 */
+	i915->params.enable_guc = ENABLE_GUC_LOAD_HUC;
 #endif
 }
 

--- a/drivers/gpu/drm/i915/i915_params.h
+++ b/drivers/gpu/drm/i915/i915_params.h
@@ -49,19 +49,9 @@ struct drm_printer;
  * mode: debugfs file permissions, one of {0400, 0600, 0}, use 0 to not create
  *       debugfs file
  */
-#ifdef __FreeBSD__
-/* Changes in default values in I915_PARAMS_FOR_EACH below:
- *
- *   enable_guc: -1 -> 0
- *   When the GuC is used, there is a great chance that the computer freezes
- *   when it reboots or is powered off. The symptom is that the scree is
- *   powered off at the time of reboot/shutdown, but the computer remains
- *   powered on.
- */
-#endif
 #define I915_PARAMS_FOR_EACH(param) \
 	param(int, modeset, -1, 0400) \
-	param(int, enable_guc, 0, 0400) \
+	param(int, enable_guc, -1, 0400) \
 	param(int, guc_log_level, -1, 0400) \
 	param(char *, guc_firmware_path, NULL, 0400) \
 	param(char *, huc_firmware_path, NULL, 0400) \


### PR DESCRIPTION
... except that GuC submission is still disabled on FreeBSD by default.

Some recent GPUs require this to work (see #418). If we need to disable GuC for some GPUs, we can add them in `uc_expand_default_options()` in `drivers/gpu/drm/i915/gt/uc/intel_uc.c`. It will be better than disabling it for everyone, requiring some user to mess with an obscure setting in `/boot/loader.conf`.

As said at the beginning however, we still disable GuC submission by default on FreeBSD. The reason is that is often prevents a computer from powering off: the kernel stops everything, the display is turned off, but the power LED is on and the fans are lightly audible.