### PR TITLE
scripts/include-chain-to-header.sh: New script to find a chain of includes

### DIFF
--- a/scripts/include-chain-to-header.sh
+++ b/scripts/include-chain-to-header.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+set -e
+
+start=$1
+target=$2
+
+visited=$PWD/_visited_in_chain.txt
+: > "$visited"
+
+linux_dir=$3
+cd "$linux_dir"
+
+list_headers() {
+	local source=$1
+
+	awk '
+	/uapi\// {
+		next;
+	}
+	/^#include/ {
+		header = $2;
+		gsub(/[<>"]/, "", header);
+		print header;
+		next;
+	}' "$source" | while read include; do
+		fd -p "/$include" arch/x86 drivers include
+	done
+}
+
+find_target_from() {
+	local from=$1
+	local target=$2
+
+	if grep -qF "$from" "$visited"; then
+		return 1;
+	else
+		echo "$from" >> "$visited"
+	fi
+
+	echo "(@ $from)"
+
+	headers=$(list_headers "$from")
+	for header in $headers; do
+		case "$header" in
+			*$target)
+				echo "*-- $target"
+				echo "|-- $from"
+				return 0
+				;;
+			*)
+				;;
+		esac
+	done
+
+	for header in $headers; do
+		if find_target_from "$header" "$target"; then
+			if test "$from" != "$start"; then
+				echo "|-- $from"
+			fi
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+find_target_from "$start" "$target"
+echo "\`-- $start"


### PR DESCRIPTION
In linuxkpi, we do not always include headers exactly like Linux because some headers are not required in our implementations. However, source files sometimes rely on namespace pollution to implicitly access an API.

This new script helps to find the chain of includes from a source file to a specified header in Linux. Here is an example:

    ./scripts/include-chain-to-header.sh \
        drivers/gpu/drm/i915/gt/intel_reset.c \
	linux/kconfig.h \
	/path/to/linux/repository

In the example above, we want to know how `intel_reset.c` indirectly include <linux/kconfig.h>.

Sponsored by:	The FreeBSD Foundation

[skip ci]