### PR TITLE
GitHub Actions: Create "Build Test" workflow [6.1]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,0 @@
-freebsd_task:
-        script:
-                - make -j4
-        matrix:
-                - name: freebsd14-amd64
-                  freebsd_instance:
-                     image_family: freebsd-14-0-snap

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,48 @@
+name: Build Test
+
+on:
+  - pull_request
+  - push
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "FreeBSD ${{ matrix.freebsd_src_ref }} — ${{ matrix.arch }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        freebsd_src_ref: ['main', 'stable/15', 'stable/14']
+        arch: ['x86_64']
+
+    steps:
+      - name: Checkout drm-kmod repository
+        uses: actions/checkout@v6
+        with:
+          path: drm-kmod
+
+      - name: Cache FreeBSD source repository
+        uses: actions/cache@v5
+        with:
+          path: src/.git
+          key: freebsd-src-${{ matrix.freebsd_src_ref }}
+
+      - name: Checkout FreeBSD source repository
+        uses: actions/checkout@v6
+        with:
+          repository: freebsd/freebsd-src
+          ref: ${{ matrix.freebsd_src_ref }}
+          path: src
+
+      - name: Compile drm-kmod
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          run: |
+            export SYSDIR=$PWD/src/sys
+            test -d "$SYSDIR"
+
+            make -j$(sysctl -n hw.ncpu) -C drm-kmod


### PR DESCRIPTION
It replaces the Cirrus CI job because Cirrus CI is going away on 2026-06-01.

The second reason is that the old Cirrus CI job was failing for months. It was basically abandonware at this point.

The new GitHub Actions based workflow can compile drm-kmod on multiple FreeBSD branches (main, stable/15 and stable/14 in this commit) and on multiple architectures (amd64 currently).

(cherry picked from commit ea5410fe177a0f9073c944ee6aa141d44137798f)