### PR TITLE
module Makefiles: define EXPORT_SYMS before including kmod.mk

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -6,6 +6,8 @@ DRM= ${.CURDIR:H:H}/drivers/gpu/drm
 
 KMOD=	amdgpu
 
+EXPORT_SYMS=	YES
+
 #
 # Work around ctfmerge(1) segfaults with recent amdgpu.ko
 #
@@ -1737,5 +1739,3 @@ CWARNFLAGS.vegam_smumgr.c=		-Wno-missing-prototypes
 
 # modules/*
 CWARNFLAGS.freesync.c=			-Wno-unused-but-set-variable
-
-EXPORT_SYMS=	YES

--- a/amd/amdkfd/Makefile
+++ b/amd/amdkfd/Makefile
@@ -7,6 +7,8 @@ SRCDIR=	${.CURDIR:H:H}/drivers/gpu/drm/amd
 
 KMOD	= amdkfd
 
+EXPORT_SYMS=	YES
+
 # XXX NOT PORTED YET:
 #	kfd_device.c : amd_iommu 
 #	kfd_chardev.c : lots of missing stuff
@@ -84,5 +86,3 @@ CWARNFLAGS.kfd_device_queue_manager.c=	-Wno-format -Wno-strict-prototypes -Wno-i
 CWARNFLAGS.kfd_doorbell.c=	-Wno-format
 CWARNFLAGS.kfd_packet_manager.c=	-Wno-format
 CWARNFLAGS.kfd_queue.c= -Wno-format
-
-EXPORT_SYMS=	YES

--- a/dmabuf/Makefile
+++ b/dmabuf/Makefile
@@ -6,6 +6,9 @@ SRCDIR=	${.CURDIR:H}/drivers/dma-buf
 .PATH:	${SRCDIR}
 
 KMOD=	dmabuf
+
+EXPORT_SYMS=	YES
+
 SRCS=	dma-buf-kmod.c \
 	dma-buf.c \
 	dma-fence-array.c \
@@ -37,5 +40,3 @@ CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 CWARNFLAGS.dma-buf.c+=	-Wno-pointer-arith
-
-EXPORT_SYMS=	YES

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -8,6 +8,9 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm
 .PATH:	${SRCDIR} ${SRCDIR}/display ${SRCDIR}/scheduler
 
 KMOD=	drm
+
+EXPORT_SYMS=	YES
+
 SRCS=	drm_atomic.c \
 	drm_atomic_helper.c \
 	drm_atomic_state_helper.c \
@@ -188,5 +191,3 @@ CWARNFLAGS.drm_ioc32.c+=			-Wno-address-of-packed-member
 CWARNFLAGS.drm_mm.c+=				-Wno-cast-qual -Wno-unused-function
 CWARNFLAGS.drm_panel_orientation_quirks.c+=	-Wno-cast-qual
 CWARNFLAGS.drm_syncobj.c+=			-Wno-unused-variable
-
-EXPORT_SYMS=	YES

--- a/dummygfx/Makefile
+++ b/dummygfx/Makefile
@@ -6,6 +6,9 @@ SRCDIR=	${.CURDIR}
 .PATH:	${SRCDIR}
 
 KMOD=	dummygfx
+
+EXPORT_SYMS=	YES
+
 SRCS=	\
 	dummygfx_drv.c \
 	dummygfx_debugfs.c
@@ -44,7 +47,5 @@ CFLAGS+= -I${SRCDIR:H}/drivers/gpu
 CFLAGS+= '-DKBUILD_MODNAME="${KMOD}"'
 CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=dummygfx_'
 CFLAGS+= -include ${SRCDIR:H}/drivers/gpu/drm/drm_os_config.h
-
-EXPORT_SYMS=	YES
 
 CWARNFLAGS += -Wno-cast-qual

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -13,6 +13,9 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/i915
 	${SRCDIR}/soc
 
 KMOD=	i915kms
+
+EXPORT_SYMS=	YES
+
 SRCS=	\
 	i915_active.c \
 	i915_cmd_parser.c \

--- a/linuxkpi_video/Makefile
+++ b/linuxkpi_video/Makefile
@@ -6,6 +6,9 @@ SRCDIR=	${.CURDIR:H}/drivers/video
 .PATH:	${SRCDIR}
 
 KMOD=	linuxkpi_video
+
+EXPORT_SYMS=    YES
+
 SRCS=	hdmi.c \
 	video_kmod.c
 
@@ -40,5 +43,3 @@ CFLAGS+= '-DLINUXKPI_PARAM_PREFIX=ttm_' -DDRM_SYSCTL_PARAM_PREFIX=_${KMOD}
 CFLAGS+= ${KCONFIG:C/(.*)/-DCONFIG_\1/}
 
 CWARNFLAGS.hdmi.c=	-Wno-cast-qual
-
-EXPORT_SYMS=    YES

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -6,6 +6,9 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/radeon
 .PATH:	${SRCDIR}
 
 KMOD=	radeonkms
+
+EXPORT_SYMS=	YES
+
 SRCS=	atom.c \
 	atombios_crtc.c \
 	atombios_dp.c \
@@ -196,5 +199,3 @@ CWARNFLAGS.trinity_dpm.c=		-Wno-unused-const-variable
 CWARNFLAGS.vce_v1_0.c=			-Wno-missing-prototypes -Wno-cast-qual
 CWARNFLAGS.vce_v2_0.c=			-Wno-missing-prototypes
 CWARNFLAGS.radeon_atpx_handler.c=	-Wno-missing-prototypes -Wno-unused-but-set-variable
-
-EXPORT_SYMS=	YES

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -6,6 +6,9 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/ttm
 .PATH:	${SRCDIR} ${SRCDIR}/..
 
 KMOD=	ttm
+
+EXPORT_SYMS=	YES
+
 SRCS=	ttm_bo.c \
 	ttm_bo_util.c \
 	ttm_bo_vm.c \
@@ -61,5 +64,3 @@ CWARNFLAGS+=-Wno-cast-qual
 .endif
 CWARNFLAGS+= -Wno-pointer-arith -Wno-format
 CWARNFLAGS+= -Wno-expansion-to-defined
-
-EXPORT_SYMS=	YES


### PR DESCRIPTION
Trying to load amdgpu leads to
  link_elf_obj: symbol dma_fence_set_deadline undefined
if debug.link_elf_obj_leak_locals is 0.

Defining EXPORT_SYMS before kmod.mk gets included in the module Makefiles avoids the EXPORT_SYMS?= NO there and makes sure EXPORT_SYMS is set correctly (to YES) in our case.

With that amdgpu loads again even if link_elf_obj_leak_locals is 0.