### PR TITLE
linux_fb: adjust KASSERTs checking screen_size

### DIFF
--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -301,27 +301,36 @@ linux_fb_get_options(const char *connector_name, char **option)
 static void
 fb_mem_wr1(struct linux_fb_info *info, uint32_t offset, uint8_t value)
 {
-	KASSERT(
-	    (offset < info->screen_size),
-	    ("Offset %#08x out of framebuffer size", offset));
+	unsigned long fbsize __diagused;
+
+	fbsize = info->screen_size != 0 ? info->screen_size :
+	    info->fix.smem_len;
+	KASSERT(offset < fbsize,
+	    ("Offset %#08x beyond framebuffer size %lx", offset, fbsize));
 	*(uint8_t *)(info->screen_base + offset) = value;
 }
 
 static void
 fb_mem_wr2(struct linux_fb_info *info, uint32_t offset, uint16_t value)
 {
-	KASSERT(
-	    (offset < info->screen_size),
-	    ("Offset %#08x out of framebuffer size", offset));
+	unsigned long fbsize __diagused;
+
+	fbsize = info->screen_size != 0 ? info->screen_size :
+	    info->fix.smem_len;
+	KASSERT(offset < fbsize,
+	    ("Offset %#08x beyond framebuffer size %lx", offset, fbsize));
 	*(uint16_t *)(info->screen_base + offset) = value;
 }
 
 static void
 fb_mem_wr4(struct linux_fb_info *info, uint32_t offset, uint32_t value)
 {
-	KASSERT(
-	    (offset < info->screen_size),
-	    ("Offset %#08x out of framebuffer size", offset));
+	unsigned long fbsize __diagused;
+
+	fbsize = info->screen_size != 0 ? info->screen_size :
+	    info->fix.smem_len;
+	KASSERT(offset < fbsize,
+	    ("Offset %#08x beyond framebuffer size %lx", offset, fbsize));
 	*(uint32_t *)(info->screen_base + offset) = value;
 }
 


### PR DESCRIPTION
The info->screen_size field is inconsistently set by the different 'fbdev' classes. In particular, drm_fbdev_generic_setup() (used by amdgpu) doesn't set it.

Therefore, I observed the following panic message with an INVARIANTS kernel:

  panic: Offset 00000000 out of framebuffer size

Obviously, this is not the intention of the assertion. Tweak the code to pull from info->fix.smem_len if screen_size is zero.

Most likely this fixes the issue: https://github.com/freebsd/drm-kmod/issues/408.