### PR TITLE
drm: fix amdgpu on my frame.work Ryzen 5 7640U

### DIFF
--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -297,12 +297,19 @@ linux_fb_get_options(const char *connector_name, char **option)
  *
  * Copied from `sys/dev/vt/hw/fb/vt_fb.c`.
  */
+#ifdef INVARIANTS
+static uint32_t
+fb_size(struct linux_fb_info *info)
+{
+	return (info->screen_size ? info->screen_size : info->fix.smem_len);
+}
+#endif
 
 static void
 fb_mem_wr1(struct linux_fb_info *info, uint32_t offset, uint8_t value)
 {
 	KASSERT(
-	    (offset < info->screen_size),
+	    (offset < fb_size(info)),
 	    ("Offset %#08x out of framebuffer size", offset));
 	*(uint8_t *)(info->screen_base + offset) = value;
 }
@@ -311,7 +318,7 @@ static void
 fb_mem_wr2(struct linux_fb_info *info, uint32_t offset, uint16_t value)
 {
 	KASSERT(
-	    (offset < info->screen_size),
+	    (offset < fb_size(info)),
 	    ("Offset %#08x out of framebuffer size", offset));
 	*(uint16_t *)(info->screen_base + offset) = value;
 }
@@ -320,7 +327,7 @@ static void
 fb_mem_wr4(struct linux_fb_info *info, uint32_t offset, uint32_t value)
 {
 	KASSERT(
-	    (offset < info->screen_size),
+	    (offset < fb_size(info)),
 	    ("Offset %#08x out of framebuffer size", offset));
 	*(uint32_t *)(info->screen_base + offset) = value;
 }


### PR DESCRIPTION
The GPU on this thing is using drm_fbdev_ttm, which does not set info->screen_size (it sets info->fix.smem_len, instead).  There's precedent for falling back to info->fix.smem_len if info->screen_size is zero in drm_fb_helper_deferred_io, so it seems that we should do the same if we're going to assert on it.

Combined with Mitchell's fix in linuxkpi for PR #436, this is enough to get a functional amdgpu running on my laptop with the 6.12-lts branch.