### PR TITLE
drm-kmod: allow amdgpu compile with x86 LINT

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_acpi.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_acpi.c
@@ -912,6 +912,15 @@ static struct amdgpu_numa_info *amdgpu_acpi_get_numa_info(uint32_t pxm)
  *
  * Returns ACPI STATUS OK with Node ID on success or the corresponding failure reason
  */
+#if defined(__FreeBSD__)
+#include "opt_acpi.h"
+
+#ifdef ACPI_DEBUG
+void AcpiUtStatusExit(UINT32, const char *, const char *, UINT32, ACPI_STATUS);
+ACPI_MODULE_NAME("AMDGPU")
+#define	_COMPONENT	ACPI_HARDWARE
+#endif
+#endif
 static acpi_status amdgpu_acpi_get_node_id(acpi_handle handle,
 				    struct amdgpu_numa_info **numa_info)
 {


### PR DESCRIPTION
Set the needed bits for ACPI_DEBUG to allow drm-kmod/amdgpu to compile LINT kernels.  This way one can finish a make universe with LOCAL_MODULES_DIR for drm-kmod, which is helpful when implementing new bits for LinuxKPI in order to make sure not to break drm-kmod.

Sponsored by:	The FreeBSD Foundation
Issue:   #354