### PR TITLE
i915: point to fwget(8) for firmware install

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_dmc.c
+++ b/drivers/gpu/drm/i915/display/intel_dmc.c
@@ -1033,8 +1033,8 @@ static void dmc_load_work_fn(struct work_struct *work)
 		drm_notice(&i915->drm, "DMC firmware homepage: %s",
 			   INTEL_DMC_FIRMWARE_URL);
 #elif defined(__FreeBSD__)
-		drm_notice(&i915->drm, "Run pkg install gpu-firmware-kmod" \
-		    " to install it\n");
+		drm_notice(&dev_priv->drm, "Run fwget(8) to install the "
+			   "correct gpu-firmware package.\n");
 #endif
 
 		return;


### PR DESCRIPTION
Rather than pointing to manually install a package which will install all poossible gpu-firmware, point to fwget(8) which should install the appropriate firmware for the device.

Issue:	#346