### PR TITLE
drm/i915: fix FreeBSD Arc A770 load blockers

### DIFF
--- a/drivers/gpu/drm/drm_os_freebsd.c
+++ b/drivers/gpu/drm/drm_os_freebsd.c
@@ -100,11 +100,13 @@ register_fictitious_range(struct drm_device *ddev, vm_paddr_t base, size_t size)
 					   VM_MEMATTR_UNCACHEABLE
 #endif
 	    );
-	MPASS(ret == 0);
-
+	if (ret) {
+		vt_unfreeze_main_vd();
+		return (ret);
+	}
 	ddev->fictitious_range_registered = true;
 
-	return (ret);
+	return (0);
 }
 
 void
@@ -113,6 +115,7 @@ unregister_fictitious_range(struct drm_device *ddev, vm_paddr_t base, size_t siz
 	if (ddev->fictitious_range_registered) {
 		vm_phys_fictitious_unreg_range(base, base + size);
 		vt_unfreeze_main_vd();
+		ddev->fictitious_range_registered = false;
 	}
 }
 

--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -61,6 +61,11 @@ struct intel_fbdev {
 	unsigned long vma_flags;
 	int preferred_bpp;
 
+#ifdef __FreeBSD__
+	/* Track whether fictitious range is owned by fbdev */
+	bool fictitious_range_registered;
+#endif
+
 	/* Whether or not fbdev hpd processing is temporarily suspended */
 	bool hpd_suspended: 1;
 	/* Set when a hotplug was received while HPD processing was suspended */
@@ -141,10 +146,13 @@ static void intel_fbdev_fb_destroy(struct fb_info *info)
 	struct intel_fbdev *ifbdev = container_of(fb_helper, struct intel_fbdev, helper);
 
 #ifdef __FreeBSD__
-	unregister_fictitious_range(
-		fb_helper->dev,
-		ifbdev->helper.info->fix.smem_start,
-		ifbdev->helper.info->fix.smem_len);
+	if (ifbdev->fictitious_range_registered) {
+		unregister_fictitious_range(
+			fb_helper->dev,
+			ifbdev->helper.info->fix.smem_start,
+			ifbdev->helper.info->fix.smem_len);
+		ifbdev->fictitious_range_registered = false;
+	}
 #endif
 
 	drm_fb_helper_fini(&ifbdev->helper);
@@ -274,7 +282,12 @@ static int intelfb_create(struct drm_fb_helper *helper,
 	 * values passed to register_fictitious_range() below are unavailable
 	 * from a generic structure set by both drivers.
 	 */
-	register_fictitious_range(dev, info->fix.smem_start, info->fix.smem_len);
+	if (!dev->fictitious_range_registered) {
+		ret = register_fictitious_range(dev, info->fix.smem_start, info->fix.smem_len);
+		if (ret)
+			goto out_unpin;
+		ifbdev->fictitious_range_registered = true;
+	}
 #endif
 
 	drm_fb_helper_fill_info(info, &ifbdev->helper, sizes);

--- a/drivers/gpu/drm/i915/gt/intel_region_lmem.c
+++ b/drivers/gpu/drm/i915/gt/intel_region_lmem.c
@@ -17,6 +17,10 @@
 #include "gt/intel_gt_mcr.h"
 #include "gt/intel_gt_regs.h"
 
+#ifdef __FreeBSD__
+#include <drm/drm_os_freebsd.h>
+#endif
+
 #ifdef CONFIG_64BIT
 #ifdef __linux__
 static void _release_bars(struct pci_dev *pdev)
@@ -137,6 +141,16 @@ region_lmem_release(struct intel_memory_region *mem)
 	int ret;
 
 	ret = intel_region_ttm_fini(mem);
+
+#ifdef __FreeBSD__
+	if (mem->fictitious_range_registered) {
+		unregister_fictitious_range(&mem->i915->drm,
+									mem->io.start,
+									resource_size(&mem->io));
+		mem->fictitious_range_registered = false;
+	}
+#endif
+
 	io_mapping_fini(&mem->iomap);
 
 	return ret;
@@ -145,6 +159,9 @@ region_lmem_release(struct intel_memory_region *mem)
 static int
 region_lmem_init(struct intel_memory_region *mem)
 {
+#ifdef __FreeBSD__
+	struct drm_device *ddev = &mem->i915->drm;
+#endif
 	int ret;
 
 	if (!io_mapping_init_wc(&mem->iomap,
@@ -156,8 +173,22 @@ region_lmem_init(struct intel_memory_region *mem)
 	if (ret)
 		goto out_no_buddy;
 
-	return 0;
+#ifdef __FreeBSD__
+	if (!ddev->fictitious_range_registered) {
+		ret = register_fictitious_range(ddev,
+										mem->io.start,
+										resource_size(&mem->io));
+		if (ret)
+			goto out_ttm_fini;
+		mem->fictitious_range_registered = true;
+	}
+#endif
 
+	return 0;
+#ifdef __FreeBSD__
+out_ttm_fini:
+	intel_region_ttm_fini(mem);
+#endif
 out_no_buddy:
 	io_mapping_fini(&mem->iomap);
 

--- a/drivers/gpu/drm/i915/i915_scatterlist.c
+++ b/drivers/gpu/drm/i915/i915_scatterlist.c
@@ -131,8 +131,17 @@ struct i915_refct_sgt *i915_rsgt_from_mm_node(const struct drm_mm_node *node,
 		}
 
 		len = min_t(u64, block_size, max_segment - sg->length);
+
+		#ifdef __linux__
 		sg->length += len;
 		sg_dma_len(sg) += len;
+		#elif defined(__FreeBSD__)
+		/* In linuxkpi/common/include/linux/scatterlist.h, there's a
+		 * "#define sg_dma_len(sg)          (sg)->length"
+		 * which causes this increment to double count when both variables are incremented
+		 */
+		sg_dma_len(sg) += len;
+		#endif
 
 		offset += len;
 		block_size -= len;
@@ -221,8 +230,17 @@ struct i915_refct_sgt *i915_rsgt_from_buddy_resource(struct ttm_resource *res,
 			}
 
 			len = min_t(u64, block_size, max_segment - sg->length);
+
+			#ifdef __linux__
 			sg->length += len;
 			sg_dma_len(sg) += len;
+			#elif defined(__FreeBSD__)
+			/* In linuxkpi/common/include/linux/scatterlist.h, there's a
+			 * "#define sg_dma_len(sg)          (sg)->length"
+			 * which causes this increment to double count when both variables are incremented
+			 */
+			sg_dma_len(sg) += len;
+			#endif
 
 			offset += len;
 			block_size -= len;

--- a/drivers/gpu/drm/i915/intel_memory_region.h
+++ b/drivers/gpu/drm/i915/intel_memory_region.h
@@ -64,6 +64,11 @@ struct intel_memory_region {
 	struct io_mapping iomap;
 	struct resource region;
 
+#ifdef __FreeBSD__
+	/* FreeBSD-only flag for whether a fictitious range was registered by this memory region */
+	bool fictitious_range_registered;
+#endif
+
 	struct resource io;
 	resource_size_t min_page_size;
 	resource_size_t total;


### PR DESCRIPTION
Related to #315.

## Summary

This PR contains two i915 fixes found while debugging Intel Arc A770 / DG2 support on 15.1-STABLE.

## Changes

1. Avoid double-incrementing i915 scatterlist length on FreeBSD.

In the LinuxKPI `scatterlist.h`, there is a preprocessor macro that aliases `sg_dma_len(sg)` as `(sg)->length`.

In `linuxkpi/common/include/linux/scatterlist.h`:

```
#define sg_dma_address(sg)      (sg)->dma_address
#define sg_dma_len(sg)          (sg)->length
```

However, in `drivers/gpu/drm/i915/i915_scatterlist.c`, there are two instances with the pattern:
```
sg->length += len;
sg_dma_len(sg) += len;
```
On FreeBSD, this was causing the `sg->length` to increment twice, leading to a kernel panic on `kldload i915kms`

2. Register FreeBSD fictitious pages for the i915 LMEM BAR

The existing i915 FreeBSD fbdev handling registers a small framebuffer range. 

On DG2, the CPU-visible aperture is larger than the fbdev range, so mappings can touch PFNs that do not have corresponding `vm_page_t` metadata.

This patch registers the CPU-visible LMEM BAR aperture during LMEM initialization, and also preserves fbdev registration as a fallback. LMEM and fbdev now each track whether they own the fictitious range, and cleanup only unregisters from the path that registers it.

I tried to follow the precedent set by the amdgpu driver for calling the `register_fictitious_range()` and `unregister_fictitious_range()` helpers. The i915 case needed some additional ownership handling logic because the fbdev path can register a small framebuffer range (on my system it was about 8 MiB).

## Testing

- Built drm-kmod from source on FreeBSD 15.1-STABLE.
- Tested on Intel Arc A770 / DG2.
- `i915kms` loads.
- DMC and GuC firmware load with `hw.i915kms.enable_guc=1`.
- `/dev/dri/card0` and `/dev/dri/renderD128` are created.
- Xorg starts with the modesetting driver.
- SDDM/Plasma starts and drives two monitors with `AccelMethod "none"`.

## Known Limitations

These changes appear to be stable on my system with `AccelMethod "none"`. 

Using hardware acceleration works initially, but I experienced two crashes with hardware acceleration enabled, one after about an hour of uptime and the other after about 5 minutes of uptime. After the crash, dmesg reports the following:

```
drmn0: [drm] *ERROR* GT0: GUC: CT: Unsolicited response message: len 1, data 0xe0000104 (fence 43258, last 43258)
drmn0: [drm] *ERROR* GT0: GUC: CT: Failed to handle HXG message (0xffffffffffffff82e) fffff8059f5e8b18h
drmn0: [drm] *ERROR* GT0: GUC: CT: Failed to process CT message (0xffffffffffffff82e) fffff8059f5e8b14h
drmn0: [drm] *ERROR* GT0: GUC: Bad context sched_state 0x6, ctx_id 4111
drmn0: [drm] *ERROR* GT0: GUC: CT: Failed to process request 1002 (0xffffffffffffffa4e)
drmn0: [drm] *ERROR* GT0: GUC: CT: Failed to process CT message (0xffffffffffffffa4e) fffff80526ca8cd4h
```

I'm currently not sure what's causing the instability, but my current assumption is that it is a failure further in the hardware acceleration pipeline. However, I thought it was best to disclose in case it is relevant to review.

Waking from sleep also appears to fail at the moment

## Contributor Note

For transparency, AI assistance was used in a limited scope during discovery and debugging. This included debugging, source navigation guidance, log/crashdump analysis, and temporary instrumentation of certain functions to gather information (all temporary instrumentation was reverted). Any behavioral code was written manually. All code changes were written, reviewed, built, and tested by me. Documentation, PR body and commit text, and code comments were all written manually by me with AI review for accuracy.