### PR TITLE
drm/i915: Adapt firmware install instructions to FreeBSD

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_dmc.c
+++ b/drivers/gpu/drm/i915/display/intel_dmc.c
@@ -1033,8 +1033,8 @@ static void dmc_load_work_fn(struct work_struct *work)
 		drm_notice(&i915->drm, "DMC firmware homepage: %s",
 			   INTEL_DMC_FIRMWARE_URL);
 #elif defined(__FreeBSD__)
-		drm_notice(&i915->drm, "Run pkg install gpu-firmware-kmod" \
-		    " to install it\n");
+		drm_notice(&i915->drm, "Run fwget(8) to install the "
+			   "correct gpu-firmware-*kmod package.\n");
 #endif
 
 		return;

--- a/drivers/gpu/drm/i915/gt/uc/intel_uc_fw.c
+++ b/drivers/gpu/drm/i915/gt/uc/intel_uc_fw.c
@@ -969,8 +969,13 @@ int intel_uc_fw_fetch(struct intel_uc_fw *uc_fw)
 			   uc_fw->file_selected.ver.major,
 			   uc_fw->file_selected.ver.minor,
 			   uc_fw->file_selected.ver.patch);
+#ifdef __linux__
 		gt_info(gt, "Consider updating your linux-firmware pkg or downloading from %s\n",
 			INTEL_UC_FIRMWARE_URL);
+#elif defined(__FreeBSD__)
+		gt_info(gt, "Run fwget(8) to install the "
+			"correct gpu-firmware-*kmod package.\n");
+#endif
 	}
 
 	if (HAS_LMEM(i915)) {


### PR DESCRIPTION
This supersedes #460.

Sponsored by:	The FreeBSD Foundation