### PR TITLE
drm/amd: Allow amdgpu compile with x86 LINT

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_acpi.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_acpi.c
@@ -39,6 +39,16 @@
 #include "amd_acpi.h"
 #include "atom.h"
 
+#if defined(__FreeBSD__)
+#include "opt_acpi.h"
+
+#ifdef ACPI_DEBUG
+void AcpiUtStatusExit(UINT32, const char *, const char *, UINT32, ACPI_STATUS);
+ACPI_MODULE_NAME("AMDGPU")
+#define	_COMPONENT	ACPI_HARDWARE
+#endif
+#endif
+
 /* Declare GUID for AMD _DSM method for XCCs */
 static const guid_t amd_xcc_dsm_guid = GUID_INIT(0x8267f5d5, 0xa556, 0x44f2,
 						 0xb8, 0xb4, 0x45, 0x56, 0x2e,


### PR DESCRIPTION
Set the needed bits for ACPI_DEBUG to allow amdgpu to compile with LINT kernels.  This way one can finish a `make universe` with `LOCAL_MODULES_DIR` pointing to `drm-kmod`, which is helpful when implementing new bits for LinuxKPI in order to make sure not to break drm-kmod.

Submitted by:	bz
Sponsored by:	The FreeBSD Foundation

(cherry picked from commit f6db340285aaab87c8fef8fe487e905880df6dca)