### PR TITLE
Include <linux/kconfig.h> from the compiler flags

### DIFF
--- a/compiler_flags.mk
+++ b/compiler_flags.mk
@@ -7,6 +7,13 @@
 CFLAGS+=	-include ${SYSDIR}/compat/linuxkpi/common/include/linux/compiler_types.h
 .endif
 
+# Other headers are always included. See the definition of `$(USERINCLUDE)` in
+# the Makefile at the root of the Linux source tree.
+.if exists(${SYSDIR}/compat/linuxkpi/common/include/linux/compiler-version.h)
+CFLAGS+=	-include ${SYSDIR}/compat/linuxkpi/common/include/linux/compiler-version.h
+.endif
+CFLAGS+=	-include ${SYSDIR}/compat/linuxkpi/common/include/linux/kconfig.h
+
 CWARNFLAGS+=	-Wno-pointer-sign
 
 # Globally silence a new warning from Clang 21.


### PR DESCRIPTION
Like we did for <linux/compiler_types.h>, we also include <linux/kconfig.h> from the compiler command line to replicate what is done in the Linux build system.

This is required because some headers rely on the availability of the `IS_ENABLED()` macro very early, before <linux/kconfig.h> has had a chance to be included through regular #include directives.

We also preventively and conditionally include
<linux/compiler-version.h>. linuxkpi doesn't have at the time of this commit. But once it does, this Makefile will be ready. The order of inclusion follows what Linux does.

This fixes build errors with DRM drivers from Linux 6.13 and 6.14.

Sponsored by:	The FreeBSD Foundation