### PR TITLE
drm_os_freebsd: expose DRM minor type via dev.drm.N.type sysctl

### DIFF
--- a/drivers/gpu/drm/drm_os_freebsd.c
+++ b/drivers/gpu/drm/drm_os_freebsd.c
@@ -139,6 +139,9 @@ drm_dev_alias(struct device *ldev, struct drm_minor *minor, const char *minor_st
 	SYSCTL_ADD_PROC(ctx_list, oid_list, OID_AUTO, "PCI_ID",
 	    CTLTYPE_STRING | CTLFLAG_RD, NULL, tmp,
 	    sysctl_pci_id, "A", "PCI vendor and device ID");
+	SYSCTL_ADD_INT(ctx_list, oid_list, OID_AUTO, "type",
+	    CTLFLAG_RD, &minor->type, 0,
+	    "DRM minor type (0=primary, 2=render)");
 
 	/*
 	 * FreeBSD won't automaticaly create the corresponding device


### PR DESCRIPTION
Add a "type" integer child to the `dev.drm.N` sysctl node to expose whether the minor is a primary (DRM_MINOR_PRIMARY == 0) or render (DRM_MINOR_RENDER == 2) node.

This enables consumers like libdrm to obtain minor type information even in a jail where the device nodes are not accessible through devfs.

Sponsored by: Defenso