### PR TITLE
dmabuf: Convert oflags to fflags in dma_buf_export

### DIFF
--- a/drivers/dma-buf/dma-buf.c
+++ b/drivers/dma-buf/dma-buf.c
@@ -578,7 +578,7 @@ dma_buf_export(const struct dma_buf_export_info *exp_info)
 	if ((err = falloc_noinstall(curthread, &fp)) != 0)
 		goto err;
 
-	finit(fp, exp_info->flags, DTYPE_DMABUF, db, &dma_buf_fileops);
+	finit(fp, FFLAGS(exp_info->flags), DTYPE_DMABUF, db, &dma_buf_fileops);
 
 	db->linux_file = fp;
 	mutex_init(&db->lock);


### PR DESCRIPTION
Since Linux has no concept of internal fflags, exp_info->flags contains oflags (e.g., O_RDWR). However, FreeBSD's finit() expects internal fflags (e.g., FREAD, FWRITE).

Passing O_RDWR (0x02) directly causes it to be evaluated purely as FWRITE (0x02) in FreeBSD, dropping the read permission entirely.  Fix this by wrapping the flags with the FFLAGS() macro.