### PR TITLE
drm/i915: Extend RCU protection in signal_irq_work() [FreeBSD]

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
+++ b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
@@ -244,7 +244,9 @@ static void signal_irq_work(struct irq_work *work)
 		}
 	}
 	atomic_dec(&b->signaler_active);
+#ifdef __linux__
 	rcu_read_unlock();
+#endif
 
 	llist_for_each_safe(signal, sn, signal) {
 		struct i915_request *rq =
@@ -262,6 +264,10 @@ static void signal_irq_work(struct irq_work *work)
 
 		i915_request_put(rq);
 	}
+#ifdef __FreeBSD__
+	/* FreeBSD irq_work taskqueues do not provide implicit RCU protection. */
+	rcu_read_unlock();
+#endif
 
 	/* Lazy irq enabling after HW submission */
 	if (!READ_ONCE(b->irq_armed) && !list_empty(&b->signalers))


### PR DESCRIPTION
## Scope and status

This is a narrow i915-local workaround for the specific `rq->context`
lifetime window in `signal_irq_work()` reported in #489. It does not restore
the generic Linux `irq_work` RCU execution semantics and must not be treated
as protection against every RCU-related use-after-free.

The preferred underlying correction is freebsd/freebsd-src#2385, which runs
all LinuxKPI `irq_work` callbacks under RCU read-side protection. If that
base-system change is accepted, this driver-local change is redundant on
branches containing it. This PR may remain useful only as a compatibility
workaround for FreeBSD branches that do not yet contain the LinuxKPI fix.

## Summary

- preserve the original Linux `rcu_read_unlock()` placement under `#ifdef __linux__`
- on FreeBSD, keep the explicit RCU read-side critical section active until the local request list has been processed
- prevent `rq->context` from being reclaimed before GuC priority retirement and the remaining request post-processing complete

Linux runs `irq_work` callbacks in interrupt context, which supplies implicit RCU read-side protection. FreeBSD LinuxKPI executes them on a taskqueue instead, so the explicit protection must cover the full request-processing loop.

## Testing

- `make -j22 KMODS=i915 DEBUG_FLAGS=-g SYSDIR=/usr/src/sys`
- `git diff --check`
- verified with `unifdef` that Linux unlocks before the loop and FreeBSD unlocks after it

Fixes #489
