### PR TITLE
radeon: recreate PCIE GART VRAM object on resume

### DIFF
--- a/drivers/gpu/drm/radeon/evergreen.c
+++ b/drivers/gpu/drm/radeon/evergreen.c
@@ -2403,8 +2403,11 @@ static int evergreen_pcie_gart_enable(struct radeon_device *rdev)
 	int r;
 
 	if (rdev->gart.robj == NULL) {
-		dev_err(rdev->dev, "No VRAM object for PCIE GART.\n");
-		return -EINVAL;
+		r = radeon_gart_table_vram_alloc(rdev);
+		if (r) {
+			dev_err(rdev->dev, "Failed to recreate VRAM object for PCIE GART: %d.\n", r);
+			return r;
+		}
 	}
 	r = radeon_gart_table_vram_pin(rdev);
 	if (r)


### PR DESCRIPTION
evergreen_pcie_gart_enable() hard-fails if rdev->gart.robj is NULL, which happens across S3 resume. radeon_gart_table_vram_pin() already restores GART entries from a system-RAM shadow independent of the BO, so just re-allocate robj instead of erroring out.