### PR TITLE
drm/i915/fbdev: Fix MTL console scanout [FreeBSD]

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -60,6 +60,7 @@ struct intel_fbdev {
 	struct i915_vma *vma;
 	unsigned long vma_flags;
 	int preferred_bpp;
+	struct drm_i915_gem_object *screen_base_object;
 
 	/* Whether or not fbdev hpd processing is temporarily suspended */
 	bool hpd_suspended: 1;
@@ -135,6 +136,19 @@ static int intel_fbdev_mmap(struct fb_info *info, struct vm_area_struct *vma)
 	return i915_gem_fb_mmap(obj, vma);
 }
 
+#ifdef __FreeBSD__
+static void intel_fbdev_unpin_screen_base(struct intel_fbdev *ifbdev)
+{
+	struct drm_i915_gem_object *obj = ifbdev->screen_base_object;
+
+	if (obj == NULL)
+		return;
+
+	ifbdev->screen_base_object = NULL;
+	i915_gem_object_unpin_map(obj);
+}
+#endif
+
 static void intel_fbdev_fb_destroy(struct fb_info *info)
 {
 	struct drm_fb_helper *fb_helper = info->par;
@@ -149,10 +163,14 @@ static void intel_fbdev_fb_destroy(struct fb_info *info)
 
 	drm_fb_helper_fini(&ifbdev->helper);
 
+#ifdef __FreeBSD__
+	intel_fbdev_unpin_screen_base(ifbdev);
+#endif
+
 	/*
-	 * We rely on the object-free to release the VMA pinning for
-	 * the info->screen_base mmaping. Leaking the VMA is simpler than
-	 * trying to rectify all the possible error paths leading here.
+	 * The GGTT iomap path relies on object-free to release the extra VMA
+	 * pin associated with info->screen_base. Leaking the VMA is simpler
+	 * than trying to rectify all the possible error paths leading here.
 	 */
 	intel_fb_unpin_vma(ifbdev->vma, ifbdev->vma_flags);
 	drm_framebuffer_remove(&ifbdev->fb->base);
@@ -256,7 +274,8 @@ static int intelfb_create(struct drm_fb_helper *helper,
 
 	obj = intel_fb_obj(&fb->base);
 
-	ret = intel_fbdev_fb_fill_info(dev_priv, info, obj, vma);
+	ret = intel_fbdev_fb_fill_info(dev_priv, info, obj, vma,
+				       &ifbdev->screen_base_object);
 	if (ret)
 		goto out_unpin;
 
@@ -306,10 +325,58 @@ out_unlock:
 	return ret;
 }
 
+#ifdef __FreeBSD__
+static void intel_fbdev_flush_object_map(struct drm_fb_helper *helper,
+					 struct drm_clip_rect *clip)
+{
+	struct intel_fbdev *ifbdev = to_intel_fbdev(helper);
+	struct drm_framebuffer *fb = helper->fb;
+	struct drm_i915_gem_object *obj;
+	u64 offset, end;
+	u32 cpp, pitch, x1, x2, y1, y2;
+
+	if (ifbdev->screen_base_object == NULL || fb == NULL)
+		return;
+
+	x1 = min_t(u32, clip->x1, fb->width);
+	x2 = min_t(u32, clip->x2, fb->width);
+	y1 = min_t(u32, clip->y1, fb->height);
+	y2 = min_t(u32, clip->y2, fb->height);
+	if (x1 >= x2 || y1 >= y2)
+		return;
+
+	cpp = fb->format->cpp[0];
+	pitch = fb->pitches[0];
+	offset = mul_u32_u32(y1, pitch);
+	if (check_add_overflow(offset, mul_u32_u32(x1, cpp), &offset) ||
+	    check_add_overflow(offset, (u64)fb->offsets[0], &offset))
+		return;
+
+	end = mul_u32_u32(y2 - 1, pitch);
+	if (check_add_overflow(end, mul_u32_u32(x2, cpp), &end) ||
+	    check_add_overflow(end, (u64)fb->offsets[0], &end))
+		return;
+
+	obj = ifbdev->screen_base_object;
+	if (offset >= obj->base.size)
+		return;
+
+	end = min_t(u64, end, obj->base.size);
+	if (offset < end) {
+		/* Make WB console writes visible to the display engine. */
+		__i915_gem_object_flush_map(obj, offset, end - offset);
+	}
+}
+#endif
+
 static int intelfb_dirty(struct drm_fb_helper *helper, struct drm_clip_rect *clip)
 {
 	if (!(clip->x1 < clip->x2 && clip->y1 < clip->y2))
 		return 0;
+
+#ifdef __FreeBSD__
+	intel_fbdev_flush_object_map(helper, clip);
+#endif
 
 	if (helper->fb->funcs->dirty)
 		return helper->fb->funcs->dirty(helper->fb, NULL, 0, 0, clip, 1);
@@ -664,6 +731,9 @@ static int intel_fbdev_client_hotplug(struct drm_client_dev *client)
 
 err_drm_fb_helper_fini:
 	drm_fb_helper_fini(fb_helper);
+#ifdef __FreeBSD__
+	intel_fbdev_unpin_screen_base(to_intel_fbdev(fb_helper));
+#endif
 err_drm_err:
 	drm_err(dev, "Failed to setup i915 fbdev emulation (ret=%d)\n", ret);
 	return ret;

--- a/drivers/gpu/drm/i915/display/intel_fbdev_fb.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev_fb.c
@@ -67,11 +67,14 @@ struct intel_framebuffer *intel_fbdev_fb_alloc(struct drm_fb_helper *helper,
 }
 
 int intel_fbdev_fb_fill_info(struct drm_i915_private *i915, struct fb_info *info,
-			     struct drm_i915_gem_object *obj, struct i915_vma *vma)
+			     struct drm_i915_gem_object *obj, struct i915_vma *vma,
+			     struct drm_i915_gem_object **screen_base_object)
 {
 	struct i915_gem_ww_ctx ww;
 	void __iomem *vaddr;
 	int ret;
+
+	*screen_base_object = NULL;
 
 	if (i915_gem_object_is_lmem(obj)) {
 		struct intel_memory_region *mem = obj->mm.region;
@@ -97,7 +100,22 @@ int intel_fbdev_fb_fill_info(struct drm_i915_private *i915, struct fb_info *info
 		if (ret)
 			continue;
 
-		vaddr = i915_vma_pin_iomap(vma);
+#ifdef __FreeBSD__
+		/*
+		 * MTL fbdev uses shmem because Wa_22018444074 excludes stolen
+		 * memory.  Map those backing pages directly: on FreeBSD, CPU
+		 * writes through MTL's GMADR aperture can miss the pages scanned
+		 * out by the display engine after the EFI framebuffer handoff.
+		 * Use WB for VT performance; the damage callback flushes writes.
+		 */
+		if (IS_METEORLAKE(i915) && i915_gem_object_is_shmem(obj)) {
+			vaddr = (void __iomem *)i915_gem_object_pin_map(obj,
+								 I915_MAP_WB);
+			if (!IS_ERR(vaddr))
+				*screen_base_object = obj;
+		} else
+#endif
+			vaddr = i915_vma_pin_iomap(vma);
 		if (IS_ERR(vaddr)) {
 			drm_err(&i915->drm,
 				"Failed to remap framebuffer into virtual memory (%pe)\n", vaddr);

--- a/drivers/gpu/drm/i915/display/intel_fbdev_fb.h
+++ b/drivers/gpu/drm/i915/display/intel_fbdev_fb.h
@@ -16,6 +16,7 @@ struct i915_vma;
 struct intel_framebuffer *intel_fbdev_fb_alloc(struct drm_fb_helper *helper,
 					       struct drm_fb_helper_surface_size *sizes);
 int intel_fbdev_fb_fill_info(struct drm_i915_private *i915, struct fb_info *info,
-			     struct drm_i915_gem_object *obj, struct i915_vma *vma);
+			     struct drm_i915_gem_object *obj, struct i915_vma *vma,
+			     struct drm_i915_gem_object **screen_base_object);
 
 #endif


### PR DESCRIPTION
## Summary

- use a direct WB object mapping for Meteor Lake's shmem-backed fbdev on FreeBSD
- flush dirty console ranges before display scanout
- balance the direct mapping pin during teardown and failed initialization

## Root cause

Wa_22018444074 prevents the Meteor Lake fbdev framebuffer from using stolen memory, so it falls back to shmem. On FreeBSD, CPU writes through the GGTT/GMADR iomap can fail to update the shmem pages scanned out by the display engine after the EFI framebuffer handoff. The observed result was a lit but black 4K HDMI display after i915 replaced efifb.

Mapping the actual shmem object with `I915_MAP_WB` makes the console visible, and flushing each dirty range makes those WB writes coherent for scanout without the severe refresh slowdown seen with a WC direct mapping. The existing GGTT iomap path remains unchanged for non-Meteor-Lake hardware.

## Testing

- clean-built `i915kms.ko` from official `master` with the module's normal `-Werror` flags
- tested EFI-to-i915 takeover on Meteor Lake graphics device `0x7d55`
- verified visible, normally refreshing VT output on a 4K HDMI television that was black before this fix
- verified no external-output regression with a 1080p HDMI monitor
- verified Plasma handoff and dual-display operation
- repeated module-load and reboot testing with no observed panic, map leak, or display regression
