### PR TITLE
drm/fb-helper: Reserve configured surface sizes [FreeBSD]

### DIFF
--- a/drivers/gpu/drm/drm_fb_helper.c
+++ b/drivers/gpu/drm/drm_fb_helper.c
@@ -1658,6 +1658,42 @@ static int __drm_fb_helper_find_sizes(struct drm_fb_helper *fb_helper,
 	return 0;
 }
 
+#ifdef __FreeBSD__
+static void
+drm_fb_helper_reserve_cmdline_modes(struct drm_fb_helper *fb_helper,
+				    struct drm_fb_helper_surface_size *sizes)
+{
+	struct drm_device *dev = fb_helper->dev;
+	struct drm_mode_config *config = &dev->mode_config;
+	struct drm_connector_list_iter conn_iter;
+	struct drm_connector *connector;
+
+	/*
+	 * Hotplug reuses the existing framebuffer and therefore cannot enable a
+	 * mode larger than the initial scanout surface.  Firmware may leave a
+	 * connector out of its active configuration even when the loader has a
+	 * mode for it, so reserve that mode's dimensions during initial setup.
+	 */
+	drm_connector_list_iter_begin(dev, &conn_iter);
+	drm_client_for_each_connector_iter(connector, &conn_iter) {
+		const struct drm_cmdline_mode *mode = &connector->cmdline_mode;
+
+		if (!mode->specified || mode->force == DRM_FORCE_OFF ||
+		    mode->xres <= 0 || mode->yres <= 0)
+			continue;
+		if ((config->max_width > 0 && mode->xres > config->max_width) ||
+		    (config->max_height > 0 && mode->yres > config->max_height))
+			continue;
+
+		sizes->surface_width = max_t(u32, sizes->surface_width,
+		    (u32)mode->xres);
+		sizes->surface_height = max_t(u32, sizes->surface_height,
+		    (u32)mode->yres);
+	}
+	drm_connector_list_iter_end(&conn_iter);
+}
+#endif
+
 static int drm_fb_helper_find_sizes(struct drm_fb_helper *fb_helper,
 				    struct drm_fb_helper_surface_size *sizes)
 {
@@ -1672,6 +1708,10 @@ static int drm_fb_helper_find_sizes(struct drm_fb_helper *fb_helper,
 
 	if (ret)
 		return ret;
+
+#ifdef __FreeBSD__
+	drm_fb_helper_reserve_cmdline_modes(fb_helper, sizes);
+#endif
 
 	/* Handle our overallocation */
 	sizes->surface_height *= drm_fbdev_overalloc;

--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -206,13 +206,13 @@ static int intelfb_create(struct drm_fb_helper *helper,
 	ifbdev->fb = NULL;
 
 	if (fb &&
-	    (sizes->fb_width > fb->base.width ||
-	     sizes->fb_height > fb->base.height)) {
+	    (sizes->surface_width > fb->base.width ||
+	     sizes->surface_height > fb->base.height)) {
 		drm_dbg_kms(&dev_priv->drm,
 			    "BIOS fb too small (%dx%d), we require (%dx%d),"
 			    " releasing it\n",
 			    fb->base.width, fb->base.height,
-			    sizes->fb_width, sizes->fb_height);
+			    sizes->surface_width, sizes->surface_height);
 		drm_framebuffer_put(&fb->base);
 		fb = NULL;
 	}


### PR DESCRIPTION
## Summary

- reserve valid loader-configured connector dimensions when allocating the initial fbdev scanout surface
- make i915 reject an inherited firmware framebuffer that is smaller than the required scanout surface

## Root cause

FreeBSD can provide per-connector modes through loader settings. Firmware may initialize only a smaller external display even though a larger internal panel also has a configured mode.

The initial fbdev allocation considers only connectors present in the first modeset. i915 then accepts the smaller inherited firmware framebuffer because it compares it against `fb_width` and `fb_height`, which describe the logical console size. A later hotplug probe is constrained by that existing framebuffer and rejects the larger panel mode as `MODE_VIRTUAL_X` or `MODE_VIRTUAL_Y`.

Reserve configured connector dimensions in `surface_width` and `surface_height`, which describe the required scanout allocation. Use those surface dimensions when deciding whether i915 can reuse the inherited framebuffer. Disabled, non-positive, and out-of-range configured modes are ignored.

## User impact

This allows fbdev to enable a larger connector after EFI initialized only a smaller display. The observed case was a 2880x1620 eDP panel remaining black after i915 took over a 1920x1080 HDMI framebuffer.

## Testing

- `git diff --check`
- clean `drm.ko` and `i915kms.ko` builds from current official `master` with the normal `-Werror` flags
- tested on Meteor Lake graphics device `0x7d55` with:
  - `kern.vt.fb.modes.eDP-1="2880x1620@120"`
  - `kern.vt.fb.modes.HDMI-A-1="1920x1080@60e"`
- verified a 2880-pixel scanout stride, both connectors enabled, visible VT output on the internal panel, and no `User-defined mode not supported` warning

Runtime testing also included the independent WB-mapping fix in #496. This PR has no source dependency on #496 and builds directly against `master`.
