### PR TITLE
drm: Define definitions of `pci_map_rom()` and `pci_unmap_rom()` conditionally [5.15]

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_bios.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_bios.c
@@ -125,7 +125,7 @@ static bool igp_read_bios_from_vram(struct amdgpu_device *adev)
 	return true;
 }
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && !defined(pci_map_rom)
 #define	pci_map_rom(pdev, sizep)					\
 	vga_pci_map_bios(device_get_parent(pdev->dev.bsddev), sizep)
 #define	pci_unmap_rom(pdev, bios)					\

--- a/drivers/gpu/drm/i915/display/intel_bios.c
+++ b/drivers/gpu/drm/i915/display/intel_bios.c
@@ -2334,7 +2334,7 @@ bool intel_bios_is_valid_vbt(const void *buf, size_t size)
 	return vbt;
 }
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && !defined(pci_map_rom)
 #define	pci_map_rom(pdev, sizep)			\
 	vga_pci_map_bios(device_get_parent(pdev->dev.bsddev), sizep)
 #define	pci_unmap_rom(pdev, bios)			\

--- a/drivers/gpu/drm/radeon/radeon_bios.c
+++ b/drivers/gpu/drm/radeon/radeon_bios.c
@@ -79,7 +79,7 @@ static bool igp_read_bios_from_vram(struct radeon_device *rdev)
 	return true;
 }
 
-#ifndef __linux__
+#if defined(__FreeBSD__) && !defined(pci_map_rom)
 #define	pci_map_rom(pdev, sizep)			\
 	vga_pci_map_bios(device_get_parent(pdev->dev.bsddev), sizep)
 #define	pci_unmap_rom(pdev, bios)			\


### PR DESCRIPTION
They are moved to linuxkpi. Using a condition allows the branch to work with both old and new versions of linuxkpi.

(cherry picked from commit 4001cc99a60a043b43d7bc68ba1f95fe15de669a)